### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM node:16
+FROM node:latest
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
fix error in node 16

"The CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
 Failed to process project graph. Run "nx reset" to fix this. Please report the issue if you keep seeing it."