### PR TITLE
ci: a tiny docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.nx
+.dist
+.node_modules

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,17 +18,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # - name: Login to Docker Registry
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.PAT_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set TAG
         run: echo TAG=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
@@ -42,3 +42,5 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/drawnix:latest
             ghcr.io/${{ github.repository_owner }}/drawnix:${{ env.TAG }}
+            pubuzhixing/drawnix:${{ env.TAG }}
+            pubuzhixing/drawnix:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # - name: Login to Docker Registry
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.PAT_TOKEN }}
+
+      - name: Set TAG
+        run: echo TAG=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
+
+      - name: Publish ${{ matrix.svc }}
+        uses: docker/build-push-action@v3
+        with:
+          file: Dockerfile
+          outputs: "type=registry,push=true"
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/drawnix:latest
+            ghcr.io/${{ github.repository_owner }}/drawnix:${{ env.TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,19 @@
+FROM node:20 AS builder 
 
-FROM node:latest
+WORKDIR /builder
 
-WORKDIR /app
-COPY . /app
+COPY . /builder
 
-RUN npm install
+RUN npm install \
+    && npm run build 
 
-EXPOSE 7200
 
-CMD ["npm", "run", "start"]
+FROM lipanski/docker-static-website:2.4.0
+
+WORKDIR /home/static
+
+COPY  --from=builder /builder/dist/apps/web/  /home/static
+
+EXPOSE 80
+
+CMD ["/busybox-httpd", "-f", "-v", "-p", "80", "-c", "httpd.conf"]


### PR DESCRIPTION
a tiny docker image base on [lipanski/docker-static-website](https://github.com/lipanski/docker-static-website)(~80kb) with `linux/amd64` and `linux/arm64` support. 

trigger when push a tag.  plz add a repo secret ` PAT_TOKEN` @pubuzhixing8  for publish the docker image to github packages