### PR TITLE
fix(eraser): adding i18n for eraser

### DIFF
--- a/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
@@ -91,7 +91,7 @@ export const BUTTONS: AppToolButtonProps[] = [
   {
     icon: EraseIcon,
     pointer: FreehandShape.eraser,
-    title: 'Erase — E',
+    titleKey: 'toolbar.eraser',
   },
   {
     icon: StraightArrowLineIcon,

--- a/packages/drawnix/src/i18n.tsx
+++ b/packages/drawnix/src/i18n.tsx
@@ -11,6 +11,7 @@ export interface Translations {
   'toolbar.mind': string;
   'toolbar.text': string;
   'toolbar.pen': string;
+  'toolbar.eraser': string;
   'toolbar.arrow': string;
   'toolbar.shape': string;
   'toolbar.image': string;
@@ -83,6 +84,7 @@ const translations: Record<Language, Translations> = {
     'toolbar.mind': '思维导图 — M',
     'toolbar.text': '文本 — T',
     'toolbar.pen': '画笔 — P',
+    'toolbar.eraser': '橡皮擦 — E',
     'toolbar.arrow': '箭头 — A',
     'toolbar.shape': '形状',
     'toolbar.image': '图片 — Cmd+U',
@@ -152,6 +154,7 @@ const translations: Record<Language, Translations> = {
     'toolbar.mind': 'Mind — M',
     'toolbar.text': 'Text — T',
     'toolbar.pen': 'Pen — P',
+    'toolbar.eraser': 'Eraser — E',
     'toolbar.arrow': 'Arrow — A',
     'toolbar.shape': 'Shape',
     'toolbar.image': 'Image — Cmd+U',


### PR DESCRIPTION
Adding i18n for eraser.
I forgot to update the title to i18n implemented in #232 
Therefore, this PR is to fix this issue that the current eraser instruction does not possess i18n feature.