### PR TITLE
fix(i18n): fix #237

### DIFF
--- a/packages/drawnix/src/components/clean-confirm/clean-confirm.tsx
+++ b/packages/drawnix/src/components/clean-confirm/clean-confirm.tsx
@@ -2,6 +2,7 @@ import { Dialog, DialogContent } from '../dialog/dialog';
 import { useDrawnix } from '../../hooks/use-drawnix';
 import './clean-confirm.scss';
 import { useBoard } from '@plait-board/react-board';
+import { useI18n } from '../../i18n';
 
 export const CleanConfirm = ({
   container,
@@ -9,6 +10,7 @@ export const CleanConfirm = ({
   container: HTMLElement | null;
 }) => {
   const { appState, setAppState } = useDrawnix();
+  const { t } = useI18n();
   const board = useBoard();
   return (
     <Dialog
@@ -18,9 +20,9 @@ export const CleanConfirm = ({
       }}
     >
       <DialogContent className="clean-confirm" container={container}>
-        <h2 className="clean-confirm__title">清除画布</h2>
+        <h2 className="clean-confirm__title">{t('cleanConfirm.title')}</h2>
         <p className="clean-confirm__description">
-          这将会清除整个画布。你是否要继续?
+          {t('cleanConfirm.description')}
         </p>
         <div className="clean-confirm__actions">
           <button
@@ -29,7 +31,7 @@ export const CleanConfirm = ({
               setAppState({ ...appState, openCleanConfirm: false });
             }}
           >
-            取消
+            {t('cleanConfirm.cancel')}
           </button>
           <button
             className="clean-confirm__button clean-confirm__button--ok"
@@ -39,7 +41,7 @@ export const CleanConfirm = ({
               setAppState({ ...appState, openCleanConfirm: false });
             }}
           >
-            确认
+            {t('cleanConfirm.ok')}
           </button>
         </div>
       </DialogContent>

--- a/packages/drawnix/src/components/menu/menu.scss
+++ b/packages/drawnix/src/components/menu/menu.scss
@@ -45,6 +45,7 @@
       border: 1px solid transparent;
       align-items: center;
       height: 2rem;
+      margin-top: 4px;
       cursor: pointer;
       border-radius: var(--border-radius-md);
 

--- a/packages/drawnix/src/i18n.tsx
+++ b/packages/drawnix/src/i18n.tsx
@@ -72,6 +72,12 @@ export interface Translations {
   // Extra tools menu items
   'extraTools.mermaidToDrawnix': string;
   'extraTools.markdownToDrawnix': string;
+
+  // Clean confirm dialog
+  'cleanConfirm.title': string;
+  'cleanConfirm.description': string;
+  'cleanConfirm.cancel': string;
+  'cleanConfirm.ok': string;
 }
 
 // Translation data
@@ -144,6 +150,12 @@ const translations: Record<Language, Translations> = {
     // Extra tools menu items
     'extraTools.mermaidToDrawnix': 'Mermaid 到 Drawnix',
     'extraTools.markdownToDrawnix': 'Markdown 到 Drawnix',
+
+    // Clean confirm dialog
+    'cleanConfirm.title': '清除画布',
+    'cleanConfirm.description': '这将会清除整个画布。你是否要继续?',
+    'cleanConfirm.cancel': '取消',
+    'cleanConfirm.ok': '确认',
   },
   en: {
     // Toolbar items
@@ -213,6 +225,12 @@ const translations: Record<Language, Translations> = {
     // Extra tools menu items
     'extraTools.mermaidToDrawnix': 'Mermaid to Drawnix',
     'extraTools.markdownToDrawnix': 'Markdown to Drawnix',
+
+    // Clean confirm dialog
+    'cleanConfirm.title': 'Clear Board',
+    'cleanConfirm.description': 'This will clear the entire board. Do you want to continue?',
+    'cleanConfirm.cancel': 'Cancel',
+    'cleanConfirm.ok': 'OK',
   },
 };
 


### PR DESCRIPTION
Currently, I only fix the first and the last issues mentioned in #237.
The auto language detection thing seems not that important and useful for now, and the default select component stuff I actually pretty love the current implementation.
Therefore, I didn't modify a large quantity of codes but just fix the small issues about the lacking i18n of clear board confirmation and the margin of language selection (actually is the menu components)