### PR TITLE
fix(cursor): set mind element css to always be inherit

### DIFF
--- a/packages/drawnix/src/styles/index.scss
+++ b/packages/drawnix/src/styles/index.scss
@@ -140,6 +140,10 @@
     &.pointer-eraser {
         .board-host-svg {
             cursor: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgMCAyMCAyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTAiIGN5PSIxMCIgcj0iNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjNjY2IiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4=') 10 10, crosshair !important;
-        }    
+        } 
+    }
+    .slate-editable-container {
+        cursor: inherit !important;
     }
 }
+


### PR DESCRIPTION
make sure every cursor css in different pointer mode should not be overwritten by mind elements' css

Fix issue mentioned in https://github.com/plait-board/drawnix/issues/247#issuecomment-3238991063