### PR TITLE
fix(hotkey): skip creation hotkey when use press special key and the function key among of alt, meta and ctrl

### DIFF
--- a/packages/drawnix/src/plugins/with-hotkey.ts
+++ b/packages/drawnix/src/plugins/with-hotkey.ts
@@ -48,53 +48,60 @@ export const buildDrawnixHotkeyPlugin = (
           event.preventDefault();
           return;
         }
-        if (event.key === 'h') {
-          BoardTransforms.updatePointerType(board, PlaitPointerType.hand);
-          updateAppState({ pointer: PlaitPointerType.hand });
-        }
-        if (event.key === 'v') {
-          BoardTransforms.updatePointerType(board, PlaitPointerType.selection);
-          updateAppState({ pointer: PlaitPointerType.selection });
-        }
-        if (event.key === 'm') {
-          setCreationMode(board, BoardCreationMode.dnd);
-          BoardTransforms.updatePointerType(board, MindPointerType.mind);
-          updateAppState({ pointer: MindPointerType.mind });
-        }
-        if (event.key === 'e') {
-          setCreationMode(board, BoardCreationMode.drawing);
-          BoardTransforms.updatePointerType(board, FreehandShape.eraser);
-          updateAppState({ pointer: FreehandShape.eraser });
-        }
-        if (event.key === 'p') {
-          setCreationMode(board, BoardCreationMode.drawing);
-          BoardTransforms.updatePointerType(board, FreehandShape.feltTipPen);
-          updateAppState({ pointer: FreehandShape.feltTipPen });
-        }
-        if (event.key === 'a' && !isHotkey(['mod+a'])(event)) {
-          // will trigger editing text
-          if (getSelectedElements(board).length === 0) {
-            setCreationMode(board, BoardCreationMode.drawing);
-            BoardTransforms.updatePointerType(board, ArrowLineShape.straight);
-            updateAppState({ pointer: ArrowLineShape.straight });
-          }
-        }
-        if (event.key === 'r' || event.key === 'o' || event.key === 't') {
-          const keyToPointer = {
-            r: BasicShapes.rectangle,
-            o: BasicShapes.ellipse,
-            t: BasicShapes.text,
-          };
-          if (keyToPointer[event.key] === BasicShapes.text) {
-            setCreationMode(board, BoardCreationMode.dnd);
-          } else {
-            setCreationMode(board, BoardCreationMode.drawing);
-          }
-          BoardTransforms.updatePointerType(board, keyToPointer[event.key]);
-          updateAppState({ pointer: keyToPointer[event.key] });
-        }
         if (isHotkey(['mod+u'])(event)) {
           addImage(board);
+        }
+        if (!event.altKey && !event.metaKey && !event.ctrlKey) {
+          if (event.key === 'h') {
+            BoardTransforms.updatePointerType(board, PlaitPointerType.hand);
+            updateAppState({ pointer: PlaitPointerType.hand });
+          }
+          if (event.key === 'v') {
+            BoardTransforms.updatePointerType(
+              board,
+              PlaitPointerType.selection
+            );
+            updateAppState({ pointer: PlaitPointerType.selection });
+          }
+          if (event.key === 'm') {
+            setCreationMode(board, BoardCreationMode.dnd);
+            BoardTransforms.updatePointerType(board, MindPointerType.mind);
+            updateAppState({ pointer: MindPointerType.mind });
+          }
+          if (event.key === 'e') {
+            setCreationMode(board, BoardCreationMode.drawing);
+            BoardTransforms.updatePointerType(board, FreehandShape.eraser);
+            updateAppState({ pointer: FreehandShape.eraser });
+          }
+          if (event.key === 'p') {
+            setCreationMode(board, BoardCreationMode.drawing);
+            BoardTransforms.updatePointerType(board, FreehandShape.feltTipPen);
+            updateAppState({ pointer: FreehandShape.feltTipPen });
+          }
+          if (event.key === 'a' && !isHotkey(['mod+a'])(event)) {
+            // will trigger editing text
+            if (getSelectedElements(board).length === 0) {
+              setCreationMode(board, BoardCreationMode.drawing);
+              BoardTransforms.updatePointerType(board, ArrowLineShape.straight);
+              updateAppState({ pointer: ArrowLineShape.straight });
+            }
+          }
+          if (event.key === 'r' || event.key === 'o' || event.key === 't') {
+            const keyToPointer = {
+              r: BasicShapes.rectangle,
+              o: BasicShapes.ellipse,
+              t: BasicShapes.text,
+            };
+            if (keyToPointer[event.key] === BasicShapes.text) {
+              setCreationMode(board, BoardCreationMode.dnd);
+            } else {
+              setCreationMode(board, BoardCreationMode.drawing);
+            }
+            BoardTransforms.updatePointerType(board, keyToPointer[event.key]);
+            updateAppState({ pointer: keyToPointer[event.key] });
+          }
+          event.preventDefault();
+          return;
         }
       }
       globalKeyDown(event);


### PR DESCRIPTION
This pull request will fix the hotkey conflict issue between drawnix and browser, for example `Cmd + R` is hotkey in browser and `R` is hotkey in drawnix creation, since `Cmd + R` should not trigger in drawnix creation.

Before:

https://github.com/user-attachments/assets/35a29bff-8a04-4d47-b28d-549abe3bce9b

After fixed:

https://github.com/user-attachments/assets/6d7775fc-194e-4026-868c-e66274a95a4a

