### PR TITLE
fix(toolbar): fix issue mentioned in #290

### DIFF
--- a/packages/drawnix/src/components/arrow-picker.tsx
+++ b/packages/drawnix/src/components/arrow-picker.tsx
@@ -5,7 +5,7 @@ import { ToolButton } from './tool-button';
 import { StraightArrowIcon, ElbowArrowIcon, CurveArrowIcon } from './icons';
 import { useBoard } from '@plait-board/react-board';
 import { Translations, useI18n } from '../i18n';
-import { BoardTransforms } from '@plait/core';
+import { BoardTransforms , PlaitBoard } from '@plait/core';
 import React from 'react';
 import { BoardCreationMode, setCreationMode } from '@plait/common';
 import { ArrowLineShape, DrawPointerType } from '@plait/draw';
@@ -52,6 +52,7 @@ export const ArrowPicker: React.FC<ArrowPickerProps> = ({ onPointerUp }) => {
               type="icon"
               size={'small'}
               visible={true}
+              selected={PlaitBoard.isPointer(board, arrow.pointer)}
               icon={arrow.icon}
               title={t(arrow.title as keyof Translations)}
               aria-label={t(arrow.title as keyof Translations)}

--- a/packages/drawnix/src/components/shape-picker.tsx
+++ b/packages/drawnix/src/components/shape-picker.tsx
@@ -11,7 +11,7 @@ import {
   RoundRectangleIcon,
   TerminalIcon,
 } from './icons';
-import { BoardTransforms } from '@plait/core';
+import { BoardTransforms , PlaitBoard } from '@plait/core';
 import React from 'react';
 import { BoardCreationMode, setCreationMode } from '@plait/common';
 import { BasicShapes, DrawPointerType, FlowchartSymbols } from '@plait/draw';
@@ -88,6 +88,7 @@ export const ShapePicker: React.FC<ShapePickerProps> = ({
                     type="icon"
                     size={'small'}
                     visible={true}
+                    selected={PlaitBoard.isPointer(board, shape.pointer)}
                     icon={shape.icon}
                     title={t((shape.title || 'toolbar.shape') as keyof Translations)}
                     aria-label={t((shape.title || 'toolbar.shape') as keyof Translations)}

--- a/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
@@ -243,6 +243,11 @@ export const CreationToolbar = () => {
                     aria-label={button.titleKey ? t(button.titleKey) : 'Shape'}
                     onPointerDown={() => {
                       setShapeOpen(!shapeOpen);
+                      if (isShapePointer(board)) {
+                        BoardTransforms.updatePointerType(board, board.pointer);
+                      } else {
+                        BoardTransforms.updatePointerType(board, button.pointer!);
+                      }
                     }}
                   />
                 </PopoverTrigger>
@@ -277,6 +282,11 @@ export const CreationToolbar = () => {
                     aria-label={button.titleKey ? t(button.titleKey) : ''}
                     onPointerDown={() => {
                       setArrowOpen(!arrowOpen);
+                      if (isArrowLinePointer(board)) {
+                        BoardTransforms.updatePointerType(board, board.pointer);
+                      } else {
+                        BoardTransforms.updatePointerType(board, button.pointer!);
+                      }
                     }}
                   />
                 </PopoverTrigger>


### PR DESCRIPTION
Fix #290 

This pull request enhances the user experience in the shape and arrow picker toolbars by improving how the currently selected pointer is visually indicated and ensuring pointer type updates are handled consistently. The changes focus on adding selection state to toolbar buttons and updating pointer logic when toggling toolbars.

**UI Improvements:**

* Added a `selected` prop to both shape and arrow picker buttons, using `PlaitBoard.isPointer` to visually indicate which pointer is currently active. [[1]](diffhunk://#diff-7945e8849770d90be6b8e60f069277c69dadd956e92dab21d358b306212ff058R55) [[2]](diffhunk://#diff-4477842771c28e9aaec496f3031406b557ae644401a4f5df057ae5c896734149R91)

**Pointer Logic Updates:**

* Updated the pointer type logic in the creation toolbar: when toggling the shape or arrow picker, the pointer type is set to either the current pointer or the button's pointer, depending on whether the current pointer matches the type being toggled. [[1]](diffhunk://#diff-f6c9c99cb530eac9ec34048c487d53806fe37cf528c82e939581cc0f560469ddR246-R250) [[2]](diffhunk://#diff-f6c9c99cb530eac9ec34048c487d53806fe37cf528c82e939581cc0f560469ddR285-R289)

**Codebase Consistency:**

* Updated imports to include `PlaitBoard` from `@plait/core` in both `arrow-picker.tsx` and `shape-picker.tsx` for the new selection logic. [[1]](diffhunk://#diff-7945e8849770d90be6b8e60f069277c69dadd956e92dab21d358b306212ff058L8-R8) [[2]](diffhunk://#diff-4477842771c28e9aaec496f3031406b557ae644401a4f5df057ae5c896734149L14-R14)