### PR TITLE
Add SVG export option in export menu

### DIFF
--- a/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
+++ b/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
@@ -17,7 +17,7 @@ import {
 import { loadFromJSON, saveAsJSON } from '../../../data/json';
 import MenuItem from '../../menu/menu-item';
 import MenuItemLink from '../../menu/menu-item-link';
-import { saveAsImage } from '../../../utils/image';
+import { saveAsImage, saveAsSVG } from '../../../utils/image';
 import { useDrawnix } from '../../../hooks/use-drawnix';
 import { useI18n } from '../../../i18n';
 import Menu from '../../menu/menu';
@@ -111,6 +111,14 @@ export const SaveAsImage = () => {
             aria-label={t('menu.exportImage.jpg')}
           >
             {t('menu.exportImage.jpg')}
+          </MenuItem>
+          <MenuItem
+            onSelect={() => {
+              saveAsSVG(board);
+            }}
+            aria-label={t('menu.exportImage.svg')}
+          >
+            {t('menu.exportImage.svg')}
           </MenuItem>
         </Menu>
       }

--- a/packages/drawnix/src/i18n/translations/ar.ts
+++ b/packages/drawnix/src/i18n/translations/ar.ts
@@ -78,6 +78,7 @@ const arTranslations: Translations = {
     "menu.exportImage": "تصدير صورة",
     "menu.exportImage.png": "PNG",
     "menu.exportImage.jpg": "JPG",
+    "menu.exportImage.svg": "SVG",
     "menu.cleanBoard": "مسح اللوحة",
     "menu.github": "غيت هب",
 

--- a/packages/drawnix/src/i18n/translations/en.ts
+++ b/packages/drawnix/src/i18n/translations/en.ts
@@ -77,6 +77,7 @@ const enTranslations: Translations = {
   'menu.exportImage': 'Export Image',
   'menu.exportImage.png': 'PNG',
   'menu.exportImage.jpg': 'JPG',
+  'menu.exportImage.svg': 'SVG',
   'menu.cleanBoard': 'Clear Board',
   'menu.github': 'GitHub',
 

--- a/packages/drawnix/src/i18n/translations/ru.ts
+++ b/packages/drawnix/src/i18n/translations/ru.ts
@@ -78,6 +78,7 @@ const ruTranslations: Translations = {
   'menu.exportImage': 'Экспортировать',
   'menu.exportImage.png': 'PNG',
   'menu.exportImage.jpg': 'JPG',
+  'menu.exportImage.svg': 'SVG',
   'menu.cleanBoard': 'Очистить доску',
   'menu.github': 'GitHub',
   

--- a/packages/drawnix/src/i18n/translations/zh.ts
+++ b/packages/drawnix/src/i18n/translations/zh.ts
@@ -78,6 +78,7 @@ const zhTranslations: Translations = {
   'menu.exportImage': '导出图片',
   'menu.exportImage.png': 'PNG',
   'menu.exportImage.jpg': 'JPG',
+  'menu.exportImage.svg': 'SVG',
   'menu.cleanBoard': '清除画布',
   'menu.github': 'GitHub',
 

--- a/packages/drawnix/src/i18n/types.ts
+++ b/packages/drawnix/src/i18n/types.ts
@@ -82,6 +82,7 @@ export interface Translations {
   'menu.exportImage': string;
   'menu.exportImage.png': string;
   'menu.exportImage.jpg': string;
+  'menu.exportImage.svg': string;
   'menu.cleanBoard': string;
   'menu.github': string;
 

--- a/packages/drawnix/src/utils/image.ts
+++ b/packages/drawnix/src/utils/image.ts
@@ -1,7 +1,7 @@
 import { getSelectedElements, PlaitBoard } from '@plait/core';
 import { base64ToBlob, boardToImage, download } from './common';
 import { fileOpen } from '../data/filesystem';
-import { IMAGE_MIME_TYPES } from '../constants';
+import { IMAGE_MIME_TYPES, MIME_TYPES } from '../constants';
 import { insertImage } from '../data/image';
 
 export const saveAsImage = (board: PlaitBoard, isTransparent: boolean) => {
@@ -27,4 +27,44 @@ export const addImage = async (board: PlaitBoard) => {
     ) as (keyof typeof IMAGE_MIME_TYPES)[],
   });
   insertImage(board, imageFile);
+};
+
+export const saveAsSVG = (board: PlaitBoard) => {
+  try {
+    // Get the main SVG element from the board
+    const hostSVG = PlaitBoard.getHost(board);
+    if (!hostSVG) {
+      console.error('Could not find board SVG element');
+      return;
+    }
+
+    // Clone the SVG to avoid modifying the original
+    const svgClone = hostSVG.cloneNode(true) as SVGSVGElement;
+    
+    // If only selected elements, we could filter the content, but for now export the whole board
+    // This ensures all visual elements including Mermaid diagrams are included
+    
+    // Get the current viewBox to ensure proper sizing
+    const viewBox = svgClone.getAttribute('viewBox');
+    if (!viewBox) {
+      // Fallback: set viewBox based on SVG dimensions
+      const rect = hostSVG.getBoundingClientRect();
+      svgClone.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`);
+    }
+
+    // Ensure SVG has proper namespace
+    svgClone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    svgClone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+
+    // Get SVG as string
+    const serializer = new XMLSerializer();
+    const svgString = serializer.serializeToString(svgClone);
+    
+    // Create blob and download
+    const blob = new Blob([svgString], { type: 'image/svg+xml' });
+    const svgName = `drawnix-${new Date().getTime()}.svg`;
+    download(blob, svgName);
+  } catch (error) {
+    console.error('Error exporting SVG:', error);
+  }
 };


### PR DESCRIPTION
Introduce an option to export the board as an SVG file in the export menu, enhancing the export functionality. Update translations for the new SVG option in multiple languages.