### PR TITLE
feat: add docker-compose support and enhance Docker documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,51 @@ npm run start
 
 ## Docker
 
+### 使用 Docker Compose（推荐）
+
+**1. 创建 docker-compose.yml 文件：**
+
+```yaml
+version: '3.8'
+
+services:
+  drawnix:
+    image: pubuzhixing/drawnix:latest  # 使用预构建镜像
+    # build: .                          # 或者从源码构建，需要先下载源码
+    container_name: drawnix-app
+    ports:
+      - "3456:80"                       # 映射到端口 3456，可按需修改
+    restart: unless-stopped
+    networks:
+      - drawnix-network
+
+networks:
+  drawnix-network:
+    driver: bridge
 ```
+
+**2. 运行服务：**
+
+```bash
+# 使用预构建镜像直接部署
+docker-compose up -d
+
+# 或者从源码构建（需要先下载源码）
+git clone https://github.com/plait-board/drawnix.git
+cd drawnix
+# 修改 docker-compose.yml，将 image 行注释，启用 build 行
+docker-compose up -d --build
+```
+
+**3. 访问应用：**
+
+[http://localhost:3456](http://localhost:3456)
+
+### 直接使用 Docker 运行
+
+```bash
 docker pull pubuzhixing/drawnix:latest
+docker run -d -p 3456:80 --name drawnix pubuzhixing/drawnix:latest
 ```
 
 ## 依赖

--- a/README_en.md
+++ b/README_en.md
@@ -108,8 +108,51 @@ npm run start
 
 ## Docker
 
+### Using Docker Compose (Recommended)
+
+**1. Create docker-compose.yml file:**
+
+```yaml
+version: '3.8'
+
+services:
+  drawnix:
+    image: pubuzhixing/drawnix:latest  # Use pre-built image
+    # build: .                          # Or build from source (requires source code)
+    container_name: drawnix-app
+    ports:
+      - "3456:80"                       # Map to port 3456, modify as needed
+    restart: unless-stopped
+    networks:
+      - drawnix-network
+
+networks:
+  drawnix-network:
+    driver: bridge
 ```
+
+**2. Run the service:**
+
+```bash
+# Deploy directly using pre-built image
+docker-compose up -d
+
+# Or build from source (requires source code download first)
+git clone https://github.com/plait-board/drawnix.git
+cd drawnix
+# Modify docker-compose.yml: comment image line, enable build line
+docker-compose up -d --build
+```
+
+**3. Access the application:**
+
+[http://localhost:3456](http://localhost:3456)
+
+### Run with Docker directly
+
+```bash
 docker pull pubuzhixing/drawnix:latest
+docker run -d -p 3456:80 --name drawnix pubuzhixing/drawnix:latest
 ```
 
 ## Dependencies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.8'
+
+services:
+  drawnix:
+    build: .
+    container_name: drawnix-app
+    ports:
+      - "3456:80"
+    restart: unless-stopped
+    environment:
+      - NODE_ENV=production
+    networks:
+      - drawnix-network
+
+  # Alternative: using pre-built image
+  # drawnix:
+  #   image: pubuzhixing/drawnix:latest
+  #   container_name: drawnix-app
+  #   ports:
+  #     - "3456:80"
+  #   restart: unless-stopped
+  #   networks:
+  #     - drawnix-network
+
+networks:
+  drawnix-network:
+    driver: bridge
+
+volumes:
+  # Add persistent volumes if needed in the future
+  # drawnix-data:


### PR DESCRIPTION
- Add docker-compose.yml with non-standard port 3456
- Update README.md and README_en.md with detailed Docker Compose instructions
- Provide clear setup steps for both pre-built image and source build options