### PR TITLE
fix: make menu click trigger show/hide submenu for mobile users to be able to choose the submenu

### DIFF
--- a/packages/drawnix/src/components/menu/menu-item.tsx
+++ b/packages/drawnix/src/components/menu/menu-item.tsx
@@ -47,6 +47,15 @@ const MenuItem = ({
     }, 100);
   };
 
+  const handleMenuItemClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (submenu) {
+      setIsOpen(!isOpen);
+      rest.onClick?.(event as any);
+    } else {
+      handleClick(event as any);
+    }
+  };
+
   if (submenu) {
     return (
       <Popover 
@@ -60,7 +69,7 @@ const MenuItem = ({
             type="button"
             className={getMenuItemClassName(className, selected || isOpen)}
             title={rest.title ?? rest['aria-label']}
-            onClick={handleClick}
+            onClick={handleMenuItemClick}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
           >


### PR DESCRIPTION
This PR fix #319 

The original setting of menu trigger `handleClick`, so the mobile user cannot select the specific language or image format to export. Therefore, this PR change the behavior of onclicking the menu.