### PR TITLE
fix(freehand): disable freehand and erase functionalities when user i…

### DIFF
--- a/packages/drawnix/src/plugins/freehand/with-freehand-create.ts
+++ b/packages/drawnix/src/plugins/freehand/with-freehand-create.ts
@@ -11,6 +11,7 @@ import { createFreehandElement, getFreehandPointers } from './utils';
 import { Freehand, FreehandShape } from './type';
 import { FreehandGenerator } from './freehand.generator';
 import { FreehandSmoother } from './smoother';
+import { isTwoFingerMode } from '@plait-board/react-board';
 
 export const withFreehandCreate = (board: PlaitBoard) => {
   const { pointerDown, pointerMove, pointerUp, globalPointerUp, touchStart } =
@@ -77,7 +78,7 @@ export const withFreehandCreate = (board: PlaitBoard) => {
   };
 
   board.pointerMove = (event: PointerEvent) => {
-    if (isDrawing) {
+    if (isDrawing && !isTwoFingerMode(board)) {
       const currentScreenPoint: Point = [event.x, event.y];
       if (
         originScreenPoint &&
@@ -109,8 +110,9 @@ export const withFreehandCreate = (board: PlaitBoard) => {
       }
       return;
     }
-
-    pointerMove(event);
+    if (isTwoFingerMode(board) && isDrawing) {
+      complete(true);
+    }
   };
 
   board.pointerUp = (event: PointerEvent) => {

--- a/packages/drawnix/src/plugins/freehand/with-freehand-erase.ts
+++ b/packages/drawnix/src/plugins/freehand/with-freehand-erase.ts
@@ -11,6 +11,7 @@ import { isHitFreehand } from './utils';
 import { Freehand, FreehandShape } from './type';
 import { CoreTransforms } from '@plait/core';
 import { LaserPointer } from '../../utils/laser-pointer';
+import { isTwoFingerMode } from '@plait-board/react-board';
 
 export const withFreehandErase = (board: PlaitBoard) => {
   const { pointerDown, pointerMove, pointerUp, globalPointerUp, touchStart } =
@@ -91,14 +92,17 @@ export const withFreehandErase = (board: PlaitBoard) => {
   };
 
   board.pointerMove = (event: PointerEvent) => {
-    if (isErasing) {
+    if (isErasing && !isTwoFingerMode(board)) {
       throttleRAF(board, 'with-freehand-erase', () => {
         const currentPoint: Point = [event.x, event.y];
         checkAndMarkFreehandElementsForDeletion(currentPoint);
       });
       return;
     }
-
+    if (isErasing && isTwoFingerMode(board)) {
+      complete();
+      return;
+    }
     pointerMove(event);
   };
 

--- a/packages/react-board/src/index.ts
+++ b/packages/react-board/src/index.ts
@@ -2,3 +2,4 @@ export * from './board';
 export * from './plugins/board';
 export * from './wrapper';
 export * from './hooks/use-board';
+export * from './plugins/with-pinch-zoom-plugin';

--- a/packages/react-board/src/plugins/with-pinch-zoom-plugin.ts
+++ b/packages/react-board/src/plugins/with-pinch-zoom-plugin.ts
@@ -16,6 +16,13 @@ interface PointerRecord {
   hasMoved: boolean;
 }
 
+export const TOUCH_RECORDS = new WeakMap<PlaitBoard, PointerRecord[]>();
+
+export const isTwoFingerMode = (board: PlaitBoard) => {
+  const pointerRecords = TOUCH_RECORDS.get(board);
+  return pointerRecords?.length === 2;
+};
+
 export const withPinchZoom = (board: PlaitBoard) => {
   const { touchStart, touchMove, touchEnd } = board;
 
@@ -30,6 +37,7 @@ export const withPinchZoom = (board: PlaitBoard) => {
       currentPoint: [touch.clientX, touch.clientY],
       hasMoved: false,
     }));
+    TOUCH_RECORDS.set(board, pointerRecords);
     if (pointerRecords.length >= 2) {
       initializeZoom = board.viewport.zoom;
     }
@@ -150,7 +158,7 @@ export const withPinchZoom = (board: PlaitBoard) => {
     if (index !== -1) {
       pointerRecords.splice(index, 1);
     }
-
+    TOUCH_RECORDS.set(board, pointerRecords);
     touchEnd(event);
   };
 


### PR DESCRIPTION
…s using two fingers

This pr will fix the issue mentioned in #331.
1. Maintain the status of two fingers pressing
2. Prevent freehand drawing and erasing when `isTwoFingerMode` is `true`.