### PR TITLE
fix(freehand): prevent from hitting the freehand when click the cente…

### DIFF
--- a/packages/drawnix/src/plugins/freehand/type.ts
+++ b/packages/drawnix/src/plugins/freehand/type.ts
@@ -4,27 +4,27 @@ import { PlaitCustomGeometry } from '@plait/draw';
 export const FreehandThemeColors = {
   [ThemeColorMode.default]: {
       strokeColor: DEFAULT_COLOR,
-      fill: '#FFFFFF'
+      fill: 'none'
   },
   [ThemeColorMode.colorful]: {
       strokeColor: '#06ADBF',
-      fill: '#CDEFF2'
+      fill: 'none'
   },
   [ThemeColorMode.soft]: {
       strokeColor: '#6D89C1',
-      fill: '#DADFEB'
+      fill: 'none'
   },
   [ThemeColorMode.retro]: {
       strokeColor: '#E9C358',
-      fill: '#F6EDCF'
+      fill: 'none'
   },
   [ThemeColorMode.dark]: {
       strokeColor: '#FFFFFF',
-      fill: '#434343'
+      fill: 'none'
   },
   [ThemeColorMode.starry]: {
       strokeColor: '#42ABE5',
-      fill: '#163F5A'
+      fill: 'none'
   }
 };
 

--- a/packages/drawnix/src/plugins/freehand/utils.ts
+++ b/packages/drawnix/src/plugins/freehand/utils.ts
@@ -43,7 +43,8 @@ export const isHitFreehand = (
 ) => {
   const antiPoint = rotateAntiPointsByElement(board, point, element) || point;
   const points = element.points;
-  if (isClosedPoints(element.points)) {
+  const fill = getFillByElement(board, element);
+  if (isClosedPoints(element.points) && fill && fill !== 'none') {
     return (
       isPointInPolygon(antiPoint, points) || isHitPolyLine(points, antiPoint)
     );


### PR DESCRIPTION
…r of closed freehand which does not include fill property and cancel default fill for closed freehand in themes FreehandThemeColors