### PR TITLE
基于 freehand-presets 的画笔更新

### DIFF
--- a/packages/drawnix/src/components/color-picker.tsx
+++ b/packages/drawnix/src/components/color-picker.tsx
@@ -32,12 +32,18 @@ export type ColorPickerProps = {
   onColorChange: (color: string) => void;
   onOpacityChange: (opacity: number) => void;
   currentColor?: string;
+  hideOpacitySlider?: boolean;
 };
 
 export const ColorPicker = React.forwardRef((props: ColorPickerProps, ref) => {
   const board = useBoard();
   const { t } = useI18n();
-  const { currentColor, onColorChange, onOpacityChange } = props;
+  const {
+    currentColor,
+    onColorChange,
+    onOpacityChange,
+    hideOpacitySlider = false,
+  } = props;
   const [selectedColor, setSelectedColor] = useState(
     (currentColor && removeHexAlpha(currentColor)) ||
       ROWS_CLASSIC_COLORS[0][0].value
@@ -48,6 +54,7 @@ export const ColorPicker = React.forwardRef((props: ColorPickerProps, ref) => {
   });
   return (
     <Stack.Col gap={3}>
+      {!hideOpacitySlider && (
         <SizeSlider
           title={t('popupToolbar.opacity')}
           step={5}
@@ -65,7 +72,8 @@ export const ColorPicker = React.forwardRef((props: ColorPickerProps, ref) => {
           }}
           disabled={selectedColor === CLASSIC_COLORS[0]['value']}
         ></SizeSlider>
-        <Stack.Col gap={2}>
+      )}
+      <Stack.Col gap={2}>
           {ROWS_CLASSIC_COLORS.map((colors, index) => (
             <Stack.Row key={index} gap={2}>
               {colors.map((color) => {

--- a/packages/drawnix/src/components/size-slider.scss
+++ b/packages/drawnix/src/components/size-slider.scss
@@ -1,38 +1,84 @@
 @import "open-color/open-color.scss";
 
 .slider-container {
-    padding: 10px 0px;
-    &.disabled {
-        opacity: 50%;
-        cursor: not-allowed;
-    
-        .slider-track,.slider-thumb {
-            cursor: not-allowed;
-        }
-    }
-    .slider-track {
-        position: relative;
-        height: 4px;
-        background-color: var(--color-gray-20);
-        border-radius: 2px;
-        cursor: pointer;
-    }
-    .slider-range {
-        position: absolute;
-        height: 100%;
-        background-color: var(--color-primary);
-        border-radius: 3px;
-    }
+  padding: 10px 0;
+
+  &.disabled {
+    opacity: 50%;
+    cursor: not-allowed;
+
+    .slider-track,
     .slider-thumb {
-        position: absolute;
-        width: 12px;
-        height: 12px;
-        background-color: $oc-white;
-        border: 2px solid var(--color-primary);
-        border-radius: 50%;
-        top: 50%;
-        transform: translate(-50%, -50%);
-        cursor: grab;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1),
+      cursor: not-allowed;
     }
+  }
+
+  &.slider-container--compact {
+    padding: 0;
+  }
+
+  .slider-track {
+    position: relative;
+    height: 4px;
+    border-radius: 999px;
+    background-color: var(--color-gray-20);
+    cursor: pointer;
+    outline: none;
+  }
+
+  .slider-range {
+    position: absolute;
+    height: 100%;
+    border-radius: inherit;
+    background-color: var(--color-primary);
+  }
+
+  .slider-thumb {
+    position: absolute;
+    top: 50%;
+    width: 12px;
+    height: 12px;
+    border: 2px solid var(--color-primary);
+    border-radius: 50%;
+    background-color: $oc-white;
+    transform: translate(-50%, -50%);
+    cursor: grab;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+
+  .slider-track:focus-visible .slider-thumb {
+    box-shadow:
+      0 0 0 3px rgba($oc-blue-4, 0.25),
+      0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+
+  &.slider-container--neutral {
+    .slider-track {
+      height: 6px;
+      background: linear-gradient(
+        90deg,
+        rgba($oc-black, 0.08) 0%,
+        rgba($oc-black, 0.14) 100%
+      );
+      box-shadow:
+        inset 0 0 0 1px rgba($oc-black, 0.06),
+        inset 0 1px 2px rgba($oc-black, 0.04);
+    }
+
+    .slider-thumb {
+      width: 14px;
+      height: 14px;
+      border-radius: 999px;
+      box-shadow:
+        0 0 0 1px rgba($oc-white, 0.5),
+        0 4px 10px rgba($oc-black, 0.14);
+    }
+
+    .slider-track:focus-visible .slider-thumb {
+      box-shadow:
+        0 0 0 3px rgba($oc-blue-4, 0.25),
+        0 0 0 1px rgba($oc-white, 0.5),
+        0 4px 10px rgba($oc-black, 0.14);
+    }
+  }
 }

--- a/packages/drawnix/src/components/size-slider.tsx
+++ b/packages/drawnix/src/components/size-slider.tsx
@@ -1,14 +1,6 @@
-import React, {
-  useState,
-  useRef,
-  useCallback,
-  useEffect,
-  useMemo,
-} from 'react';
-import { toFixed } from '@plait/core';
+import React, { useEffect, useRef, useState } from 'react';
 import './size-slider.scss';
 import classNames from 'classnames';
-import { throttle } from 'lodash';
 
 interface SliderProps {
   min?: number;
@@ -17,10 +9,22 @@ interface SliderProps {
   defaultValue?: number;
   disabled?: boolean;
   title?: string;
+  variant?: 'default' | 'neutral';
+  compact?: boolean;
   onChange?: (value: number) => void;
   beforeStart?: () => void;
   afterEnd?: () => void;
 }
+
+const clamp = (value: number, min: number, max: number) => {
+  return Math.min(max, Math.max(min, value));
+};
+
+const getStepPrecision = (step: number) => {
+  const stepText = step.toString();
+  const decimalIndex = stepText.indexOf('.');
+  return decimalIndex === -1 ? 0 : stepText.length - decimalIndex - 1;
+};
 
 export const SizeSlider: React.FC<SliderProps> = ({
   min = 0,
@@ -32,95 +36,123 @@ export const SizeSlider: React.FC<SliderProps> = ({
   beforeStart,
   afterEnd,
   title,
+  variant = 'default',
+  compact = false,
 }) => {
   const [isDragging, setIsDragging] = useState(false);
   const [value, setValue] = useState(defaultValue);
   const sliderRef = useRef<HTMLDivElement>(null);
-  const thumbRef = useRef<HTMLDivElement>(null);
+  const precision = getStepPrecision(step);
   const percentage = ((value - min) / (max - min)) * 100;
 
-  const handleSliderChange = useCallback(
-    throttle(
-      (event: React.MouseEvent<HTMLDivElement> | MouseEvent) => {
-        if (sliderRef.current && thumbRef.current) {
-          const sliderRect = sliderRef.current.getBoundingClientRect();
-          const thumbRect = thumbRef.current.getBoundingClientRect();
-          const x = event.clientX - sliderRect.left;
-          const thumbPercentage = toFixed(
-            (thumbRect.width / 2 / sliderRect.width) * 100
-          );
-          let percentage = Math.min(Math.max(x / sliderRect.width, 0), 1);
-          if (percentage >= (100 - thumbPercentage) / 100) {
-            percentage = 1;
-          } else if (percentage <= thumbPercentage / 100) {
-            percentage = 0;
-          }
-          const newValue =
-            Math.round((percentage * (max - min)) / step) * step + min;
-          setValue(newValue);
-          onChange && onChange(newValue);
-        }
-      },
-      50,
-      { leading: true, trailing: true }
-    ),
-    [min, max, step, onChange]
-  );
+  useEffect(() => {
+    setValue(defaultValue);
+  }, [defaultValue]);
 
-  const handlePointerDown = useCallback(() => {
-    const handleMouseMove = (e: MouseEvent) => {
-      setIsDragging(true);
-      handleSliderChange(e);
-    };
-    const handleMouseUp = () => {
-      document.removeEventListener('pointermove', handleMouseMove);
-      document.removeEventListener('pointerup', handleMouseUp);
-      afterEnd && afterEnd();
-      setTimeout(() => {
-        setIsDragging(false);
-      }, 0);
-    };
+  const updateValue = (nextValue: number) => {
+    const roundedValue = Number(
+      (
+        Math.round((nextValue - min) / step) * step + min
+      ).toFixed(precision)
+    );
+    const normalizedValue = clamp(roundedValue, min, max);
+    setValue(normalizedValue);
+    onChange?.(normalizedValue);
+  };
 
-    document.addEventListener('pointermove', handleMouseMove);
-    document.addEventListener('pointerup', handleMouseUp);
-  }, [handleSliderChange]);
+  const updateValueByClientX = (clientX: number) => {
+    if (!sliderRef.current) {
+      return;
+    }
+    const sliderRect = sliderRef.current.getBoundingClientRect();
+    const ratio = clamp((clientX - sliderRect.left) / sliderRect.width, 0, 1);
+    updateValue(min + ratio * (max - min));
+  };
 
-  useEffect(()=>{
-    setValue(defaultValue)
-  },[defaultValue])
+  const finishDragging = (currentTarget: HTMLDivElement, pointerId: number) => {
+    if (currentTarget.hasPointerCapture(pointerId)) {
+      currentTarget.releasePointerCapture(pointerId);
+    }
+    setIsDragging(false);
+    afterEnd?.();
+  };
 
   return (
     <div
       data-tooltip
       title={title}
-      className={classNames('slider-container', { disabled: disabled })}
+      className={classNames('slider-container', {
+        disabled,
+        'slider-container--neutral': variant === 'neutral',
+        'slider-container--compact': compact,
+      })}
     >
       <div
         ref={sliderRef}
         className="slider-track"
-        onClick={(event) => {
-          if (disabled || isDragging) {
-            return;
-          }
-          handleSliderChange(event);
-        }}
+        role="slider"
+        tabIndex={disabled ? -1 : 0}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        aria-valuetext={title || String(value)}
         onPointerDown={(event) => {
           event.preventDefault();
           if (disabled) {
             return;
           }
-          beforeStart && beforeStart();
-          handlePointerDown();
+          beforeStart?.();
+          event.currentTarget.setPointerCapture(event.pointerId);
+          setIsDragging(true);
+          updateValueByClientX(event.clientX);
+        }}
+        onPointerMove={(event) => {
+          if (!isDragging || disabled) {
+            return;
+          }
+          event.preventDefault();
+          updateValueByClientX(event.clientX);
+        }}
+        onPointerUp={(event) => {
+          finishDragging(event.currentTarget, event.pointerId);
+        }}
+        onPointerCancel={(event) => {
+          finishDragging(event.currentTarget, event.pointerId);
+        }}
+        onKeyDown={(event) => {
+          if (disabled) {
+            return;
+          }
+          let nextValue = value;
+
+          if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') {
+            nextValue = value - step;
+          }
+          if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
+            nextValue = value + step;
+          }
+          if (event.key === 'Home') {
+            nextValue = min;
+          }
+          if (event.key === 'End') {
+            nextValue = max;
+          }
+
+          if (nextValue !== value) {
+            event.preventDefault();
+            updateValue(nextValue);
+          }
         }}
       >
+        {variant !== 'neutral' && (
+          <div
+            className="slider-range"
+            style={{
+              width: `${percentage}%`,
+            }}
+          />
+        )}
         <div
-          className="slider-range"
-          style={{
-            width: `${percentage}%`,
-          }}
-        />
-        <div
-          ref={thumbRef}
           className="slider-thumb"
           style={{
             left: `${percentage}%`,

--- a/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
@@ -8,7 +8,6 @@ import {
   SelectionIcon,
   ShapeIcon,
   TextIcon,
-  EraseIcon,
   StraightArrowLineIcon,
   FeltTipPenIcon,
   ImageIcon,
@@ -132,7 +131,7 @@ export const isShapePointer = (board: PlaitBoard) => {
 
 export const CreationToolbar = () => {
   const board = useBoard();
-  const { appState } = useDrawnix();
+  const { appState, setAppState } = useDrawnix();
   const { t } = useI18n();
   const setPointer = useSetPointer();
   const container = PlaitBoard.getBoardContainer(board);
@@ -142,14 +141,14 @@ export const CreationToolbar = () => {
   const [shapeOpen, setShapeOpen] = useState(false);
   const [lastFreehandButton, setLastFreehandButton] =
     useState<AppToolButtonProps>(
-      BUTTONS.find((button) => button.key === PopupKey.freehand)!
+      BUTTONS.find((button) => button.key === PopupKey.freehand) || BUTTONS[4]
     );
-  const [lastShapePointer, setLastShapePointer] = useState<DrawPointerType>(
-    SHAPES[0].pointer
-  );
-  const [lastArrowPointer, setLastArrowPointer] = useState<DrawPointerType>(
-    ARROWS[0].pointer
-  );
+  const [lastShapePointer, setLastShapePointer] = useState<
+    DrawPointerType | undefined
+  >(SHAPES[0].pointer);
+  const [lastArrowPointer, setLastArrowPointer] = useState<
+    DrawPointerType | undefined
+  >(ARROWS[0].pointer);
 
   const onPointerDown = (pointer: DrawnixPointerType) => {
     setCreationMode(board, BoardCreationMode.dnd);
@@ -169,11 +168,28 @@ export const CreationToolbar = () => {
 
   const checkCurrentPointerIsFreehand = (board: PlaitBoard) => {
     return PlaitBoard.isInPointer(board, [
-      FreehandShape.feltTipPen, 
+      FreehandShape.feltTipPen,
       FreehandShape.eraser,
     ]);
   };
 
+  const updateFreehandSettings = (
+    presetIndex: number,
+    nextSettings: Partial<(typeof appState)['freehandPresets'][number]>
+  ) => {
+    setAppState((currentAppState) => ({
+      ...currentAppState,
+      freehandPresets: currentAppState.freehandPresets.map((preset, index) => {
+        if (index !== presetIndex) {
+          return preset;
+        }
+        return {
+          ...preset,
+          ...nextSettings,
+        };
+      }),
+    }));
+  };
 
   return (
     <Island
@@ -183,7 +199,7 @@ export const CreationToolbar = () => {
       <Stack.Row gap={1}>
         {BUTTONS.map((button, index) => {
           if (appState.isMobile && button.pointer === PlaitPointerType.hand) {
-            return <></>;
+            return null;
           }
           if (button.key === PopupKey.freehand) {
             return (
@@ -208,7 +224,9 @@ export const CreationToolbar = () => {
                     aria-label={lastFreehandButton.titleKey ? t(lastFreehandButton.titleKey) : 'Freehand'}
                     onPointerDown={() => {
                       setFreehandOpen(!freehandOpen);
-                      onPointerDown(lastFreehandButton.pointer!);
+                      if (lastFreehandButton.pointer) {
+                        onPointerDown(lastFreehandButton.pointer);
+                      }
                     }}
                     onPointerUp={() => {
                       onPointerUp();
@@ -217,18 +235,37 @@ export const CreationToolbar = () => {
                 </PopoverTrigger>
                 <PopoverContent container={container}>
                   <FreehandPanel
+                    freehandPresets={appState.freehandPresets}
+                    activePresetIndex={appState.activeFreehandPresetIndex}
+                    onPresetSelect={(presetIndex: number) => {
+                      setAppState((currentAppState) => ({
+                        ...currentAppState,
+                        activeFreehandPresetIndex: presetIndex,
+                      }));
+                    }}
+                    onStrokeColorSelect={(
+                      presetIndex: number,
+                      strokeColor?: string
+                    ) => {
+                      updateFreehandSettings(presetIndex, {
+                        strokeColor,
+                      });
+                    }}
+                    onStrokeWidthSelect={(
+                      presetIndex: number,
+                      strokeWidth: number
+                    ) => {
+                      updateFreehandSettings(presetIndex, {
+                        strokeWidth,
+                      });
+                    }}
                     onPointerUp={(pointer: DrawnixPointerType) => {
                       setPointer(pointer);
-                      const matched = FREEHANDS.find(
-                        (item: (typeof FREEHANDS)[number]) =>
-                          item.type === 'tool' && item.pointer === pointer
+                      const selectedButton = FREEHANDS.find(
+                        (item) => item.pointer === pointer
                       );
-                      if (matched && matched.type === 'tool') {
-                        setLastFreehandButton({
-                          icon: matched.icon,
-                          pointer: matched.pointer,
-                          titleKey: matched.titleKey,
-                        });
+                      if (selectedButton) {
+                        setLastFreehandButton(selectedButton);
                       }
                     }}
                   ></FreehandPanel>
@@ -263,10 +300,13 @@ export const CreationToolbar = () => {
                       if (isShapePointer(board)) {
                         BoardTransforms.updatePointerType(board, board.pointer);
                       } else {
-                        setPointer(lastShapePointer as DrawnixPointerType);
+                        setPointer(lastShapePointer || SHAPES[0].pointer);
                         setCreationMode(board, BoardCreationMode.drawing);
-                        BoardTransforms.updatePointerType(board, lastShapePointer);
-                      } 
+                        BoardTransforms.updatePointerType(
+                          board,
+                          lastShapePointer || SHAPES[0].pointer
+                        );
+                      }
                     }}
                   />
                 </PopoverTrigger>
@@ -274,7 +314,7 @@ export const CreationToolbar = () => {
                   <ShapePicker
                     onPointerUp={(pointer: DrawPointerType) => {
                       setShapeOpen(false);
-                      setPointer(pointer as DrawnixPointerType);
+                      setPointer(pointer);
                       setLastShapePointer(pointer);
                     }}
                   ></ShapePicker>
@@ -305,9 +345,12 @@ export const CreationToolbar = () => {
                       if (isArrowLinePointer(board)) {
                         BoardTransforms.updatePointerType(board, board.pointer);
                       } else {
-                        setPointer(lastArrowPointer as DrawnixPointerType);
-                        BoardTransforms.updatePointerType(board, lastArrowPointer || ARROWS[0].pointer);
-                        BoardTransforms.updatePointerType(board, lastArrowPointer);
+                        setCreationMode(board, BoardCreationMode.drawing);
+                        BoardTransforms.updatePointerType(
+                          board,
+                          lastArrowPointer || ARROWS[0].pointer
+                        );
+                        setPointer(lastArrowPointer || ARROWS[0].pointer);
                       }
                     }}
                   />
@@ -316,7 +359,7 @@ export const CreationToolbar = () => {
                   <ArrowPicker
                     onPointerUp={(pointer: DrawPointerType) => {
                       setArrowOpen(false);
-                      setPointer(pointer as DrawnixPointerType);
+                      setPointer(pointer);
                       setLastArrowPointer(pointer);
                     }}
                   ></ArrowPicker>

--- a/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
@@ -29,7 +29,7 @@ import {
   DrawPointerType,
   FlowchartSymbols,
 } from '@plait/draw';
-import { FreehandPanel , FREEHANDS } from './freehand-panel/freehand-panel';
+import { FreehandPanel } from './freehand-panel/freehand-panel';
 import { ShapePicker } from '../shape-picker';
 import { ArrowPicker } from '../arrow-picker';
 import { useState } from 'react';
@@ -42,9 +42,10 @@ import {
 } from '../../hooks/use-drawnix';
 import { ExtraToolsButton } from './extra-tools/extra-tools-button';
 import { addImage } from '../../utils/image';
-import { useI18n } from '../../i18n';
+import { Translations, useI18n } from '../../i18n';
 import { SHAPES } from '../shape-picker';
 import { ARROWS } from '../arrow-picker';
+import { FREEHANDS } from '../../constants/freehand';
 
 export enum PopupKey {
   'shape' = 'shape',
@@ -53,7 +54,7 @@ export enum PopupKey {
 }
 
 type AppToolButtonProps = {
-  titleKey?: keyof typeof import('../../i18n').Translations;
+  titleKey?: keyof Translations;
   name?: string;
   icon: React.ReactNode;
   pointer?: DrawnixPointerType;
@@ -143,8 +144,12 @@ export const CreationToolbar = () => {
     useState<AppToolButtonProps>(
       BUTTONS.find((button) => button.key === PopupKey.freehand)!
     );
-  const [lastShapePointer, setLastShapePointer] = useState<string | undefined>(SHAPES[0].pointer);
-  const [lastArrowPointer, setLastArrowPointer] = useState<string | undefined>(ARROWS[0].pointer);
+  const [lastShapePointer, setLastShapePointer] = useState<DrawPointerType>(
+    SHAPES[0].pointer
+  );
+  const [lastArrowPointer, setLastArrowPointer] = useState<DrawPointerType>(
+    ARROWS[0].pointer
+  );
 
   const onPointerDown = (pointer: DrawnixPointerType) => {
     setCreationMode(board, BoardCreationMode.dnd);
@@ -214,9 +219,17 @@ export const CreationToolbar = () => {
                   <FreehandPanel
                     onPointerUp={(pointer: DrawnixPointerType) => {
                       setPointer(pointer);
-                      setLastFreehandButton(
-                        FREEHANDS.find((button) => button.pointer === pointer)!
+                      const matched = FREEHANDS.find(
+                        (item: (typeof FREEHANDS)[number]) =>
+                          item.type === 'tool' && item.pointer === pointer
                       );
+                      if (matched && matched.type === 'tool') {
+                        setLastFreehandButton({
+                          icon: matched.icon,
+                          pointer: matched.pointer,
+                          titleKey: matched.titleKey,
+                        });
+                      }
                     }}
                   ></FreehandPanel>
                 </PopoverContent>
@@ -250,9 +263,9 @@ export const CreationToolbar = () => {
                       if (isShapePointer(board)) {
                         BoardTransforms.updatePointerType(board, board.pointer);
                       } else {
-                        setPointer(lastShapePointer || SHAPES[0].pointer)
+                        setPointer(lastShapePointer as DrawnixPointerType);
                         setCreationMode(board, BoardCreationMode.drawing);
-                        BoardTransforms.updatePointerType(board, lastShapePointer || SHAPES[0].pointer);
+                        BoardTransforms.updatePointerType(board, lastShapePointer);
                       } 
                     }}
                   />
@@ -261,7 +274,7 @@ export const CreationToolbar = () => {
                   <ShapePicker
                     onPointerUp={(pointer: DrawPointerType) => {
                       setShapeOpen(false);
-                      setPointer(pointer);
+                      setPointer(pointer as DrawnixPointerType);
                       setLastShapePointer(pointer);
                     }}
                   ></ShapePicker>
@@ -292,9 +305,9 @@ export const CreationToolbar = () => {
                       if (isArrowLinePointer(board)) {
                         BoardTransforms.updatePointerType(board, board.pointer);
                       } else {
-                        setCreationMode(board, BoardCreationMode.drawing);
+                        setPointer(lastArrowPointer as DrawnixPointerType);
                         BoardTransforms.updatePointerType(board, lastArrowPointer || ARROWS[0].pointer);
-                        setPointer(lastArrowPointer || ARROWS[0].pointer);
+                        BoardTransforms.updatePointerType(board, lastArrowPointer);
                       }
                     }}
                   />
@@ -303,7 +316,7 @@ export const CreationToolbar = () => {
                   <ArrowPicker
                     onPointerUp={(pointer: DrawPointerType) => {
                       setArrowOpen(false);
-                      setPointer(pointer);
+                      setPointer(pointer as DrawnixPointerType);
                       setLastArrowPointer(pointer);
                     }}
                   ></ArrowPicker>

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-panel.tsx
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-panel.tsx
@@ -2,41 +2,63 @@ import classNames from 'classnames';
 import { Island } from '../../island';
 import Stack from '../../stack';
 import { ToolButton } from '../../tool-button';
-import {
-  EraseIcon,
-  FeltTipPenIcon,
-} from '../../icons';
-import { BoardTransforms } from '@plait/core';
+import { BoardTransforms, PlaitBoard } from '@plait/core';
 import React from 'react';
 import { BoardCreationMode, setCreationMode } from '@plait/common';
-import { FreehandShape } from '../../../plugins/freehand/type';
 import { useBoard } from '@plait-board/react-board';
-import { splitRows } from '../../../utils/common';
-import {
-    DrawnixPointerType,
-} from '../../../hooks/use-drawnix';
+import { DrawnixPointerType } from '../../../hooks/use-drawnix';
 import { useI18n } from '../../../i18n';
+import { FreehandShape } from '../../../plugins/freehand/type';
+import {
+  FreeHandItems,
+  FreehandItem,
+  FreehandPresetItem,
+  FreehandToolItem,
+} from '../../../constants/freehand';
+import {
+  FreehandStylePresetItem,
+  FreehandStylePreset,
+} from './freehand-style-preset-item';
+import './freehand-style-preset-item.scss';
 
-export interface FreehandProps {
-    titleKey: string;
-    icon: React.ReactNode;
-    pointer: DrawnixPointerType;
-}
+const FreehandStyleDivider = () => (
+  <span className="freehand-style-divider" aria-hidden="true" />
+);
 
-export const FREEHANDS: FreehandProps[] = [
-  {
-      icon: FeltTipPenIcon,
-      pointer: FreehandShape.feltTipPen,
-      titleKey: 'toolbar.pen',
-    },
-    {
-      icon: EraseIcon,
-      pointer: FreehandShape.eraser,
-      titleKey: 'toolbar.eraser',
-    },
-];
+FreehandStyleDivider.displayName = 'FreehandStyleDivider';
 
-const ROW_FREEHANDS = splitRows(FREEHANDS, 5);
+const FIRST_PRESET_ID =
+  FreeHandItems.find(
+    (item): item is FreehandPresetItem => item.type === 'preset'
+  )?.id || '';
+
+const isFreehandPresetItem = (item: FreehandItem): item is FreehandPresetItem =>
+  item.type === 'preset';
+
+const isFreehandToolItem = (item: FreehandItem): item is FreehandToolItem =>
+  item.type === 'tool';
+
+const toPreset = (item: FreehandPresetItem): FreehandStylePreset => ({
+  id: item.id,
+  color: item.color,
+  size: item.size,
+});
+
+const updatePresetInItems = (
+  items: FreehandItem[],
+  presetId: string,
+  updater: (preset: FreehandPresetItem) => FreehandPresetItem
+): FreehandItem[] =>
+  items.map((item) =>
+    isFreehandPresetItem(item) && item.id === presetId ? updater(item) : item
+  );
+
+const getPresetItems = (items: FreehandItem[]): FreehandPresetItem[] =>
+  items.filter((item): item is FreehandPresetItem =>
+    isFreehandPresetItem(item)
+  );
+const getToolItems = (items: FreehandItem[]): FreehandToolItem[] =>
+  items.filter((item): item is FreehandToolItem => isFreehandToolItem(item));
 
 export type FreehandPickerProps = {
   onPointerUp: (pointer: DrawnixPointerType) => void;
@@ -47,39 +69,75 @@ export const FreehandPanel: React.FC<FreehandPickerProps> = ({
 }) => {
   const { t } = useI18n();
   const board = useBoard();
+  const container = PlaitBoard.getBoardContainer(board);
+  const [items, setItems] = React.useState<FreehandItem[]>(FreeHandItems);
+  const [activePresetId, setActivePresetId] =
+    React.useState<string>(FIRST_PRESET_ID);
+  const toolItems = getToolItems(items);
+  const presetItems = getPresetItems(items);
+  const showPresets = board.pointer !== FreehandShape.eraser;
+
+  const saveAndApplyPreset = (preset: FreehandPresetItem) => {
+    // do nothing now
+  };
+
   return (
     <Island padding={1}>
-      <Stack.Col gap={1}>
-        {ROW_FREEHANDS.map((rowFreehands, rowIndex) => {
-          return (
-            <Stack.Row gap={1} key={rowIndex}>
-              {rowFreehands.map((freehand, index) => {
-                return (
-                  <ToolButton
-                    key={index}
-                    className={classNames({ fillable: false })}
-                    selected={board.pointer === freehand.pointer}
-                    type="icon"
-                    size={'small'}
-                    visible={true}
-                    icon={freehand.icon}
-                    title={t(freehand.titleKey)}
-                    aria-label={t(freehand.titleKey)}
-                    onPointerDown={() => {
-                      setCreationMode(board, BoardCreationMode.dnd);
-                      BoardTransforms.updatePointerType(board, freehand.pointer);
-                    }}
-                    onPointerUp={() => {
-                      setCreationMode(board, BoardCreationMode.drawing);
-                      onPointerUp(freehand.pointer);
-                    }}
-                  />
-                );
-              })}
-            </Stack.Row>
-          );
-        })}
-      </Stack.Col>
+      <Stack.Row gap={1} align="start" className="freehand-style-list">
+        {toolItems.map((freehand, index) => (
+          <ToolButton
+            key={index}
+            className={classNames({ fillable: false })}
+            selected={board.pointer === freehand.pointer}
+            type="icon"
+            size={'small'}
+            visible={true}
+            icon={freehand.icon}
+            title={t(freehand.titleKey)}
+            aria-label={t(freehand.titleKey)}
+            onPointerDown={() => {
+              setCreationMode(board, BoardCreationMode.dnd);
+              BoardTransforms.updatePointerType(board, freehand.pointer);
+            }}
+            onPointerUp={() => {
+              setCreationMode(board, BoardCreationMode.drawing);
+              onPointerUp(freehand.pointer);
+            }}
+          />
+        ))}
+        {showPresets && toolItems.length > 0 && presetItems.length > 0 && (
+          <FreehandStyleDivider />
+        )}
+        {showPresets &&
+          presetItems.map((preset) => (
+          <FreehandStylePresetItem
+            key={preset.id}
+            preset={toPreset(preset)}
+            selected={activePresetId === preset.id}
+            container={container}
+            onSelect={() => {
+              setActivePresetId(preset.id);
+              saveAndApplyPreset(preset);
+            }}
+            onColorChange={(color) => {
+              setItems((value) =>
+                updatePresetInItems(value, preset.id, (item) => ({
+                  ...item,
+                  color,
+                }))
+              );
+            }}
+            onSizeChange={(size) => {
+              setItems((value) =>
+                updatePresetInItems(value, preset.id, (item) => ({
+                  ...item,
+                  size,
+                }))
+              );
+            }}
+          />
+        ))}
+      </Stack.Row>
     </Island>
   );
 };

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-panel.tsx
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-panel.tsx
@@ -10,16 +10,19 @@ import { DrawnixPointerType } from '../../../hooks/use-drawnix';
 import { useI18n } from '../../../i18n';
 import { FreehandShape } from '../../../plugins/freehand/type';
 import {
-  FreeHandItems,
-  FreehandItem,
-  FreehandPresetItem,
-  FreehandToolItem,
+  FREEHANDS,
+  FREEHAND_PRESET_IDS,
+  type FreehandPresetId,
 } from '../../../constants/freehand';
 import {
   FreehandStylePresetItem,
-  FreehandStylePreset,
+  type FreehandStylePreset,
 } from './freehand-style-preset-item';
 import './freehand-style-preset-item.scss';
+import {
+  DEFAULT_FREEHAND_PRESETS,
+  type FreehandDrawOptions,
+} from '../../../plugins/freehand/presets';
 
 const FreehandStyleDivider = () => (
   <span className="freehand-style-divider" aria-hidden="true" />
@@ -27,64 +30,55 @@ const FreehandStyleDivider = () => (
 
 FreehandStyleDivider.displayName = 'FreehandStyleDivider';
 
-const FIRST_PRESET_ID =
-  FreeHandItems.find(
-    (item): item is FreehandPresetItem => item.type === 'preset'
-  )?.id || '';
+const getPresetId = (presetIndex: number): FreehandPresetId | string => {
+  return FREEHAND_PRESET_IDS[presetIndex] || `preset-${presetIndex + 1}`;
+};
 
-const isFreehandPresetItem = (item: FreehandItem): item is FreehandPresetItem =>
-  item.type === 'preset';
-
-const isFreehandToolItem = (item: FreehandItem): item is FreehandToolItem =>
-  item.type === 'tool';
-
-const toPreset = (item: FreehandPresetItem): FreehandStylePreset => ({
-  id: item.id,
-  color: item.color,
-  size: item.size,
+const toPreset = (
+  presetIndex: number,
+  preset: FreehandDrawOptions
+): FreehandStylePreset => ({
+  id: getPresetId(presetIndex),
+  color: preset.strokeColor,
+  size: preset.strokeWidth,
 });
 
-const updatePresetInItems = (
-  items: FreehandItem[],
-  presetId: string,
-  updater: (preset: FreehandPresetItem) => FreehandPresetItem
-): FreehandItem[] =>
-  items.map((item) =>
-    isFreehandPresetItem(item) && item.id === presetId ? updater(item) : item
-  );
-
-const getPresetItems = (items: FreehandItem[]): FreehandPresetItem[] =>
-  items.filter((item): item is FreehandPresetItem =>
-    isFreehandPresetItem(item)
-  );
-const getToolItems = (items: FreehandItem[]): FreehandToolItem[] =>
-  items.filter((item): item is FreehandToolItem => isFreehandToolItem(item));
-
 export type FreehandPickerProps = {
+  freehandPresets: FreehandDrawOptions[];
+  activePresetIndex: number;
+  onPresetSelect: (presetIndex: number) => void;
+  onStrokeColorSelect: (presetIndex: number, strokeColor?: string) => void;
+  onStrokeWidthSelect: (presetIndex: number, strokeWidth: number) => void;
   onPointerUp: (pointer: DrawnixPointerType) => void;
 };
 
 export const FreehandPanel: React.FC<FreehandPickerProps> = ({
+  freehandPresets,
+  activePresetIndex,
+  onPresetSelect,
+  onStrokeColorSelect,
+  onStrokeWidthSelect,
   onPointerUp,
 }) => {
   const { t } = useI18n();
   const board = useBoard();
   const container = PlaitBoard.getBoardContainer(board);
-  const [items, setItems] = React.useState<FreehandItem[]>(FreeHandItems);
-  const [activePresetId, setActivePresetId] =
-    React.useState<string>(FIRST_PRESET_ID);
-  const toolItems = getToolItems(items);
-  const presetItems = getPresetItems(items);
+  const presets = freehandPresets.length
+    ? freehandPresets
+    : DEFAULT_FREEHAND_PRESETS;
   const showPresets = board.pointer !== FreehandShape.eraser;
 
-  const saveAndApplyPreset = (preset: FreehandPresetItem) => {
-    // do nothing now
+  const saveAndApplyPreset = (presetIndex: number) => {
+    onPresetSelect(presetIndex);
+    setCreationMode(board, BoardCreationMode.drawing);
+    BoardTransforms.updatePointerType(board, FreehandShape.feltTipPen);
+    onPointerUp(FreehandShape.feltTipPen);
   };
 
   return (
     <Island padding={1}>
       <Stack.Row gap={1} align="start" className="freehand-style-list">
-        {toolItems.map((freehand, index) => (
+        {FREEHANDS.map((freehand, index) => (
           <ToolButton
             key={index}
             className={classNames({ fillable: false })}
@@ -105,38 +99,27 @@ export const FreehandPanel: React.FC<FreehandPickerProps> = ({
             }}
           />
         ))}
-        {showPresets && toolItems.length > 0 && presetItems.length > 0 && (
+        {showPresets && FREEHANDS.length > 0 && presets.length > 0 && (
           <FreehandStyleDivider />
         )}
         {showPresets &&
-          presetItems.map((preset) => (
-          <FreehandStylePresetItem
-            key={preset.id}
-            preset={toPreset(preset)}
-            selected={activePresetId === preset.id}
-            container={container}
-            onSelect={() => {
-              setActivePresetId(preset.id);
-              saveAndApplyPreset(preset);
-            }}
-            onColorChange={(color) => {
-              setItems((value) =>
-                updatePresetInItems(value, preset.id, (item) => ({
-                  ...item,
-                  color,
-                }))
-              );
-            }}
-            onSizeChange={(size) => {
-              setItems((value) =>
-                updatePresetInItems(value, preset.id, (item) => ({
-                  ...item,
-                  size,
-                }))
-              );
-            }}
-          />
-        ))}
+          presets.map((preset, presetIndex) => (
+            <FreehandStylePresetItem
+              key={getPresetId(presetIndex)}
+              preset={toPreset(presetIndex, preset)}
+              selected={activePresetIndex === presetIndex}
+              container={container}
+              onSelect={() => {
+                saveAndApplyPreset(presetIndex);
+              }}
+              onColorChange={(color) => {
+                onStrokeColorSelect(presetIndex, color);
+              }}
+              onSizeChange={(size) => {
+                onStrokeWidthSelect(presetIndex, size);
+              }}
+            />
+          ))}
       </Stack.Row>
     </Island>
   );

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.scss
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.scss
@@ -1,0 +1,38 @@
+.drawnix {
+  .freehand-style-list {
+    margin-top: 0;
+  }
+
+  .freehand-style-divider {
+    width: 1px;
+    height: 20px;
+    margin: 0 calc(var(--space-factor));
+    background-color: var(--color-gray-20);
+    align-self: center;
+  }
+
+  .freehand-style-preset__preview {
+    width: var(--default-icon-size);
+    height: var(--default-icon-size);
+    border-radius: 50%;
+    border: 1px solid var(--color-gray-40);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--color-surface-lowest);
+  }
+
+  .freehand-style-preset__dot {
+    border-radius: 50%;
+    display: inline-flex;
+  }
+
+  .freehand-style-setting {
+    width: auto;
+    min-width: auto;
+  }
+
+  .freehand-style-setting .slider-container {
+    width: 100%;
+  }
+}

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.tsx
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.tsx
@@ -7,10 +7,22 @@ import Stack from '../../stack';
 import { SizeSlider } from '../../size-slider';
 import { useI18n } from '../../../i18n';
 import { ColorPicker } from '../../color-picker';
+import { useBoard } from '@plait-board/react-board';
+import { getFreehandDefaultStrokeColor } from '../../../plugins/freehand/utils';
+import {
+  FREEHAND_STROKE_WIDTH_STEP,
+  MAX_FREEHAND_STROKE_WIDTH,
+  MIN_FREEHAND_STROKE_WIDTH,
+} from '../../../plugins/freehand/type';
+import { isNoColor } from '../../../utils/color';
+
+const formatSize = (value: number) => {
+  return value.toFixed(2).replace(/\.?0+$/, '');
+};
 
 export interface FreehandStylePreset {
   id: string;
-  color: string;
+  color?: string;
   size: number;
 }
 
@@ -19,7 +31,7 @@ export interface FreehandStylePresetItemProps {
   selected: boolean;
   container: HTMLElement | null;
   onSelect: () => void;
-  onColorChange: (color: string) => void;
+  onColorChange: (color?: string) => void;
   onSizeChange: (size: number) => void;
 }
 
@@ -32,7 +44,10 @@ export const FreehandStylePresetItem: React.FC<FreehandStylePresetItemProps> = (
   onSizeChange,
 }) => {
   const { t } = useI18n();
+  const board = useBoard();
   const [open, setOpen] = React.useState(false);
+  const swatchColor =
+    preset.color || getFreehandDefaultStrokeColor(board.theme.themeColorMode);
 
   React.useEffect(() => {
     if (!selected) {
@@ -73,13 +88,13 @@ export const FreehandStylePresetItem: React.FC<FreehandStylePresetItemProps> = (
           <span
             className="freehand-style-preset__preview"
             style={{
-              borderColor: preset.color,
+              borderColor: swatchColor,
             }}
           >
             <span
               className="freehand-style-preset__dot"
               style={{
-                backgroundColor: preset.color,
+                backgroundColor: swatchColor,
                 width: `${Math.min(Math.max(preset.size + 1, 4), 14)}px`,
                 height: `${Math.min(Math.max(preset.size + 1, 4), 14)}px`,
               }}
@@ -91,11 +106,13 @@ export const FreehandStylePresetItem: React.FC<FreehandStylePresetItemProps> = (
         <Island padding={4} className="freehand-style-setting">
           <Stack.Col gap={3}>
             <SizeSlider
-              title={t('popupToolbar.stroke')}
-              min={1}
-              max={24}
-              step={1}
+              title={formatSize(preset.size)}
+              min={MIN_FREEHAND_STROKE_WIDTH}
+              max={MAX_FREEHAND_STROKE_WIDTH}
+              step={FREEHAND_STROKE_WIDTH_STEP}
               defaultValue={preset.size}
+              variant="neutral"
+              compact={true}
               onChange={(value) => {
                 onSizeChange(value);
               }}
@@ -104,7 +121,9 @@ export const FreehandStylePresetItem: React.FC<FreehandStylePresetItemProps> = (
               currentColor={preset.color}
               hideOpacitySlider={true}
               onColorChange={(selectedColor: string) => {
-                onColorChange(selectedColor);
+                onColorChange(
+                  isNoColor(selectedColor) ? undefined : selectedColor
+                );
               }}
               onOpacityChange={() => {
                 return;

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.tsx
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import classNames from 'classnames';
+import { ToolButton } from '../../tool-button';
+import { Popover, PopoverContent, PopoverTrigger } from '../../popover/popover';
+import { Island } from '../../island';
+import Stack from '../../stack';
+import { SizeSlider } from '../../size-slider';
+import { useI18n } from '../../../i18n';
+import { ColorPicker } from '../../color-picker';
+
+export interface FreehandStylePreset {
+  id: string;
+  color: string;
+  size: number;
+}
+
+export interface FreehandStylePresetItemProps {
+  preset: FreehandStylePreset;
+  selected: boolean;
+  container: HTMLElement | null;
+  onSelect: () => void;
+  onColorChange: (color: string) => void;
+  onSizeChange: (size: number) => void;
+}
+
+export const FreehandStylePresetItem: React.FC<FreehandStylePresetItemProps> = ({
+  preset,
+  selected,
+  container,
+  onSelect,
+  onColorChange,
+  onSizeChange,
+}) => {
+  const { t } = useI18n();
+  const [open, setOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!selected) {
+      setOpen(false);
+    }
+  }, [selected]);
+
+  return (
+    <Popover
+      open={open}
+      sideOffset={12}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) {
+          onSelect();
+          setOpen(true);
+          return;
+        }
+        setOpen(false);
+      }}
+    >
+      <PopoverTrigger asChild>
+        <ToolButton
+          className={classNames('freehand-style-preset')}
+          selected={selected || open}
+          type="button"
+          size="small"
+          visible={true}
+          aria-label={`${t('toolbar.pen')} ${preset.id}`}
+          onPointerUp={() => {
+            if (selected) {
+              setOpen(!open);
+              return;
+            }
+            onSelect();
+            setOpen(false);
+          }}
+        >
+          <span
+            className="freehand-style-preset__preview"
+            style={{
+              borderColor: preset.color,
+            }}
+          >
+            <span
+              className="freehand-style-preset__dot"
+              style={{
+                backgroundColor: preset.color,
+                width: `${Math.min(Math.max(preset.size + 1, 4), 14)}px`,
+                height: `${Math.min(Math.max(preset.size + 1, 4), 14)}px`,
+              }}
+            />
+          </span>
+        </ToolButton>
+      </PopoverTrigger>
+      <PopoverContent container={container}>
+        <Island padding={4} className="freehand-style-setting">
+          <Stack.Col gap={3}>
+            <SizeSlider
+              title={t('popupToolbar.stroke')}
+              min={1}
+              max={24}
+              step={1}
+              defaultValue={preset.size}
+              onChange={(value) => {
+                onSizeChange(value);
+              }}
+            />
+            <ColorPicker
+              currentColor={preset.color}
+              hideOpacitySlider={true}
+              onColorChange={(selectedColor: string) => {
+                onColorChange(selectedColor);
+              }}
+              onOpacityChange={() => {
+                return;
+              }}
+            ></ColorPicker>
+          </Stack.Col>
+        </Island>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/packages/drawnix/src/constants/freehand.ts
+++ b/packages/drawnix/src/constants/freehand.ts
@@ -1,70 +1,31 @@
-import { CLASSIC_COLORS } from './color';
 import type React from 'react';
 import { EraseIcon, FeltTipPenIcon } from '../components/icons';
 import { FreehandShape } from '../plugins/freehand/type';
 import type { Translations } from '../i18n';
 
-export const DEFAULT_FREEHAND_PRESET_SIZES = {
-  preset1: 2,
-  preset2: 6,
-  preset3: 10,
-} as const;
+export const FREEHAND_PRESET_IDS = [
+  'preset-1',
+  'preset-2',
+  'preset-3',
+] as const;
+
+export type FreehandPresetId = (typeof FREEHAND_PRESET_IDS)[number];
 
 export type FreehandToolItem = {
-  type: 'tool';
   titleKey: keyof Translations;
   icon: React.ReactNode;
   pointer: FreehandShape.feltTipPen | FreehandShape.eraser;
 };
 
-export type FreehandPresetItem = {
-  type: 'preset';
-  id: string;
-  color: string;
-  size: number;
-};
-
-export type FreehandItem = FreehandToolItem | FreehandPresetItem;
-
-const getClassicColorValue = (name: string) => {
-  return CLASSIC_COLORS.find((item) => item.name === name)?.value;
-};
-
-export const DEFAULT_FREEHAND_PRESETS: FreehandPresetItem[] = [
+export const FREEHANDS: FreehandToolItem[] = [
   {
-    type: 'preset',
-    id: 'preset-1',
-    color: getClassicColorValue('color.default') || CLASSIC_COLORS[1].value,
-    size: DEFAULT_FREEHAND_PRESET_SIZES.preset1,
-  },
-  {
-    type: 'preset',
-    id: 'preset-2',
-    color: getClassicColorValue('color.red') || CLASSIC_COLORS[5].value,
-    size: DEFAULT_FREEHAND_PRESET_SIZES.preset2,
-  },
-  {
-    type: 'preset',
-    id: 'preset-3',
-    color: getClassicColorValue('color.green') || CLASSIC_COLORS[6].value,
-    size: DEFAULT_FREEHAND_PRESET_SIZES.preset3,
-  },
-];
-
-export const FreeHandItems: FreehandItem[] = [
-  {
-    type: 'tool',
     icon: FeltTipPenIcon,
     pointer: FreehandShape.feltTipPen,
     titleKey: 'toolbar.pen',
   },
   {
-    type: 'tool',
     icon: EraseIcon,
     pointer: FreehandShape.eraser,
     titleKey: 'toolbar.eraser',
   },
-  ...DEFAULT_FREEHAND_PRESETS,
 ];
-
-export const FREEHANDS = FreeHandItems;

--- a/packages/drawnix/src/constants/freehand.ts
+++ b/packages/drawnix/src/constants/freehand.ts
@@ -1,0 +1,70 @@
+import { CLASSIC_COLORS } from './color';
+import type React from 'react';
+import { EraseIcon, FeltTipPenIcon } from '../components/icons';
+import { FreehandShape } from '../plugins/freehand/type';
+import type { Translations } from '../i18n';
+
+export const DEFAULT_FREEHAND_PRESET_SIZES = {
+  preset1: 2,
+  preset2: 6,
+  preset3: 10,
+} as const;
+
+export type FreehandToolItem = {
+  type: 'tool';
+  titleKey: keyof Translations;
+  icon: React.ReactNode;
+  pointer: FreehandShape.feltTipPen | FreehandShape.eraser;
+};
+
+export type FreehandPresetItem = {
+  type: 'preset';
+  id: string;
+  color: string;
+  size: number;
+};
+
+export type FreehandItem = FreehandToolItem | FreehandPresetItem;
+
+const getClassicColorValue = (name: string) => {
+  return CLASSIC_COLORS.find((item) => item.name === name)?.value;
+};
+
+export const DEFAULT_FREEHAND_PRESETS: FreehandPresetItem[] = [
+  {
+    type: 'preset',
+    id: 'preset-1',
+    color: getClassicColorValue('color.default') || CLASSIC_COLORS[1].value,
+    size: DEFAULT_FREEHAND_PRESET_SIZES.preset1,
+  },
+  {
+    type: 'preset',
+    id: 'preset-2',
+    color: getClassicColorValue('color.red') || CLASSIC_COLORS[5].value,
+    size: DEFAULT_FREEHAND_PRESET_SIZES.preset2,
+  },
+  {
+    type: 'preset',
+    id: 'preset-3',
+    color: getClassicColorValue('color.green') || CLASSIC_COLORS[6].value,
+    size: DEFAULT_FREEHAND_PRESET_SIZES.preset3,
+  },
+];
+
+export const FreeHandItems: FreehandItem[] = [
+  {
+    type: 'tool',
+    icon: FeltTipPenIcon,
+    pointer: FreehandShape.feltTipPen,
+    titleKey: 'toolbar.pen',
+  },
+  {
+    type: 'tool',
+    icon: EraseIcon,
+    pointer: FreehandShape.eraser,
+    titleKey: 'toolbar.eraser',
+  },
+  ...DEFAULT_FREEHAND_PRESETS,
+];
+
+export const FREEHANDS = FreeHandItems;

--- a/packages/drawnix/src/drawnix.tsx
+++ b/packages/drawnix/src/drawnix.tsx
@@ -10,7 +10,7 @@ import {
   ThemeColorMode,
   Viewport,
 } from '@plait/core';
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import { withGroup } from '@plait/common';
 import { withDraw } from '@plait/draw';
 import { MindThemeColors, withMind } from '@plait/mind';
@@ -40,6 +40,7 @@ import { LinkPopup } from './components/popup/link-popup/link-popup';
 import { I18nProvider } from './i18n';
 import { Tutorial } from './components/tutorial';
 import { LASER_POINTER_CLASS_NAME } from './utils/laser-pointer';
+import { DEFAULT_FREEHAND_PRESETS } from './plugins/freehand/presets';
 
 export type DrawnixProps = {
   value: PlaitElement[];
@@ -80,6 +81,10 @@ export const Drawnix: React.FC<DrawnixProps> = ({
       pointer: PlaitPointerType.hand,
       isMobile: md.mobile() !== null,
       isPencilMode: false,
+      freehandPresets: DEFAULT_FREEHAND_PRESETS.map((preset) => ({
+        ...preset,
+      })),
+      activeFreehandPresetIndex: 0,
       openDialogType: null,
       openCleanConfirm: false,
     };
@@ -92,10 +97,10 @@ export const Drawnix: React.FC<DrawnixProps> = ({
   }
 
   const updateAppState = (newAppState: Partial<DrawnixState>) => {
-    setAppState({
-      ...appState,
+    setAppState((currentAppState) => ({
+      ...currentAppState,
       ...newAppState,
-    });
+    }));
   };
 
   const plugins: PlaitPlugin[] = [

--- a/packages/drawnix/src/hooks/use-drawnix.tsx
+++ b/packages/drawnix/src/hooks/use-drawnix.tsx
@@ -3,12 +3,18 @@
  * context whenever changes occur.
  */
 import { PlaitBoard, PlaitPointerType } from '@plait/core';
-import { createContext, useContext } from 'react';
+import {
+  createContext,
+  useContext,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
 import { MindPointerType } from '@plait/mind';
 import { DrawPointerType } from '@plait/draw';
 import { FreehandShape } from '../plugins/freehand/type';
 import { Editor } from 'slate';
 import { LinkElement } from '@plait/common';
+import { FreehandDrawOptions } from '../plugins/freehand/presets';
 
 export enum DialogType {
   mermaidToDrawnix = 'mermaidToDrawnix',
@@ -38,6 +44,8 @@ export type DrawnixState = {
   pointer: DrawnixPointerType;
   isMobile: boolean;
   isPencilMode: boolean;
+  freehandPresets: FreehandDrawOptions[];
+  activeFreehandPresetIndex: number;
   openDialogType: DialogType | null;
   openCleanConfirm: boolean;
   linkState?: LinkState | null;
@@ -45,12 +53,12 @@ export type DrawnixState = {
 
 export const DrawnixContext = createContext<{
   appState: DrawnixState;
-  setAppState: (appState: DrawnixState) => void;
+  setAppState: Dispatch<SetStateAction<DrawnixState>>;
 } | null>(null);
 
 export const useDrawnix = (): {
   appState: DrawnixState;
-  setAppState: (appState: DrawnixState) => void;
+  setAppState: Dispatch<SetStateAction<DrawnixState>>;
 } => {
   const context = useContext(DrawnixContext);
 
@@ -64,8 +72,8 @@ export const useDrawnix = (): {
 };
 
 export const useSetPointer = () => {
-  const { appState, setAppState } = useDrawnix();
+  const { setAppState } = useDrawnix();
   return (pointer: DrawnixPointerType) => {
-    setAppState({ ...appState, pointer });
+    setAppState((appState) => ({ ...appState, pointer }));
   };
 };

--- a/packages/drawnix/src/plugins/freehand/presets.ts
+++ b/packages/drawnix/src/plugins/freehand/presets.ts
@@ -1,0 +1,42 @@
+export const DEFAULT_FREEHAND_STROKE_WIDTH = 2;
+
+export const MIN_FREEHAND_STROKE_WIDTH = 1;
+
+export const MAX_FREEHAND_STROKE_WIDTH = 12;
+
+export const FREEHAND_STROKE_WIDTH_STEP = 0.25;
+
+export type FreehandDrawOptions = {
+  strokeColor?: string;
+  strokeWidth: number;
+};
+
+export const DEFAULT_FREEHAND_PRESETS: FreehandDrawOptions[] = [
+  {
+    strokeWidth: DEFAULT_FREEHAND_STROKE_WIDTH,
+  },
+  {
+    strokeColor: '#FF4500',
+    strokeWidth: 6,
+  },
+  {
+    strokeColor: '#2ECC71',
+    strokeWidth: 10,
+  },
+];
+
+export const resolveFreehandDrawOptions = (
+  drawOptions: Partial<FreehandDrawOptions> = {}
+) => {
+  const normalizedDrawOptions = {} as Partial<FreehandDrawOptions>;
+
+  if (typeof drawOptions.strokeColor === 'string' && drawOptions.strokeColor) {
+    normalizedDrawOptions.strokeColor = drawOptions.strokeColor;
+  }
+
+  if (typeof drawOptions.strokeWidth === 'number') {
+    normalizedDrawOptions.strokeWidth = drawOptions.strokeWidth;
+  }
+
+  return normalizedDrawOptions;
+};

--- a/packages/drawnix/src/plugins/freehand/type.ts
+++ b/packages/drawnix/src/plugins/freehand/type.ts
@@ -1,6 +1,13 @@
 import { DEFAULT_COLOR, Point, ThemeColorMode } from '@plait/core';
 import { PlaitCustomGeometry } from '@plait/draw';
 
+export {
+  DEFAULT_FREEHAND_STROKE_WIDTH,
+  FREEHAND_STROKE_WIDTH_STEP,
+  MAX_FREEHAND_STROKE_WIDTH,
+  MIN_FREEHAND_STROKE_WIDTH,
+} from './presets';
+
 export const FreehandThemeColors = {
   [ThemeColorMode.default]: {
       strokeColor: DEFAULT_COLOR,
@@ -41,7 +48,12 @@ export const FREEHAND_TYPE = 'freehand';
 export type Freehand = PlaitCustomGeometry<typeof FREEHAND_TYPE, Point[], FreehandShape>
 
 export const Freehand = {
-  isFreehand: (value: any): value is Freehand => {
-    return value.type === FREEHAND_TYPE;
+  isFreehand: (value: unknown): value is Freehand => {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'type' in value &&
+      value.type === FREEHAND_TYPE
+    );
   },
 };

--- a/packages/drawnix/src/plugins/freehand/utils.spec.ts
+++ b/packages/drawnix/src/plugins/freehand/utils.spec.ts
@@ -1,0 +1,37 @@
+import { resolveFreehandDrawOptions } from './presets';
+
+describe('freehand utils', () => {
+  it('preserves theme-following presets when color is omitted', () => {
+    expect(
+      resolveFreehandDrawOptions({
+        strokeWidth: 2,
+      })
+    ).toEqual({
+      strokeWidth: 2,
+    });
+  });
+
+  it('keeps explicit stroke presets', () => {
+    expect(
+      resolveFreehandDrawOptions({
+        strokeColor: '#FF4500',
+        strokeWidth: 3.25,
+      })
+    ).toEqual({
+      strokeColor: '#FF4500',
+      strokeWidth: 3.25,
+    });
+  });
+
+  it('keeps explicit default-like preset values', () => {
+    expect(
+      resolveFreehandDrawOptions({
+        strokeColor: '#000000',
+        strokeWidth: 2,
+      })
+    ).toEqual({
+      strokeColor: '#000000',
+      strokeWidth: 2,
+    });
+  });
+});

--- a/packages/drawnix/src/plugins/freehand/utils.ts
+++ b/packages/drawnix/src/plugins/freehand/utils.ts
@@ -12,6 +12,11 @@ import {
 } from '@plait/core';
 import { Freehand, FreehandShape, FreehandThemeColors } from './type';
 import {
+  DEFAULT_FREEHAND_PRESETS,
+  type FreehandDrawOptions,
+  resolveFreehandDrawOptions,
+} from './presets';
+import {
   DefaultDrawStyle,
   isClosedCustomGeometry,
   isClosedPoints,
@@ -19,19 +24,38 @@ import {
   isRectangleHitRotatedPoints,
 } from '@plait/draw';
 
+type FreehandAppState = {
+  activeFreehandPresetIndex?: number;
+  freehandPresets?: FreehandDrawOptions[];
+};
+
 export function getFreehandPointers() {
   return [FreehandShape.feltTipPen, FreehandShape.eraser];
 }
 
+export const getFreehandDrawOptions = (board: PlaitBoard) => {
+  const appState = (board as PlaitBoard & { appState?: FreehandAppState })
+    .appState;
+  const activePresetIndex = appState?.activeFreehandPresetIndex || 0;
+  const activePreset =
+    appState?.freehandPresets?.[activePresetIndex] ||
+    DEFAULT_FREEHAND_PRESETS[activePresetIndex] ||
+    DEFAULT_FREEHAND_PRESETS[0];
+
+  return resolveFreehandDrawOptions(activePreset);
+};
+
 export const createFreehandElement = (
   shape: FreehandShape,
-  points: Point[]
+  points: Point[],
+  drawOptions: Partial<FreehandDrawOptions> = {}
 ): Freehand => {
   const element: Freehand = {
     id: idCreator(),
     type: 'freehand',
     shape,
     points,
+    ...resolveFreehandDrawOptions(drawOptions),
   };
   return element;
 };

--- a/packages/drawnix/src/plugins/freehand/with-freehand-create.ts
+++ b/packages/drawnix/src/plugins/freehand/with-freehand-create.ts
@@ -7,7 +7,11 @@ import {
   toViewBoxPoint,
 } from '@plait/core';
 import { isDrawingMode } from '@plait/common';
-import { createFreehandElement, getFreehandPointers } from './utils';
+import {
+  createFreehandElement,
+  getFreehandDrawOptions,
+  getFreehandPointers,
+} from './utils';
 import { Freehand, FreehandShape } from './type';
 import { FreehandGenerator } from './freehand.generator';
 import { FreehandSmoother } from './smoother';
@@ -37,10 +41,11 @@ export const withFreehandCreate = (board: PlaitBoard) => {
   const complete = (cancel?: boolean) => {
     if (isDrawing) {
       const pointer = PlaitBoard.getPointer(board) as FreehandShape;
+      const drawOptions = getFreehandDrawOptions(board);
       if (isSnappingStartAndEnd) {
         points.push(points[0]);
       }
-      temporaryElement = createFreehandElement(pointer, points);
+      temporaryElement = createFreehandElement(pointer, points, drawOptions);
     }
     if (temporaryElement && !cancel) {
       Transforms.insertNode(board, temporaryElement, [board.children.length]);
@@ -102,7 +107,11 @@ export const withFreehandCreate = (board: PlaitBoard) => {
         );
         points.push(newPoint);
         const pointer = PlaitBoard.getPointer(board) as FreehandShape;
-        temporaryElement = createFreehandElement(pointer, points);
+        temporaryElement = createFreehandElement(
+          pointer,
+          points,
+          getFreehandDrawOptions(board)
+        );
         generator.processDrawing(
           temporaryElement,
           PlaitBoard.getElementTopHost(board)


### PR DESCRIPTION
这次主要做了这些事：
1. 将 freehand preset 的真实状态接到 Drawnix appState，而不是只停留在面板本地状态。
2. 将 preset 的颜色和粗细真正应用到新创建的 freehand 笔迹。
3. 将 freehand 的粗细调节迁移到共享的 `SizeSlider`，并调整了交互：
   - 支持 `0.25` 步长
   - 去掉蓝色 active range
   - 去掉顶部额外预览
   - 使用更顺滑的拖动更新方式
4. 保留当前默认颜色逻辑，这一轮没有额外调整默认颜色的语义表现。
5. 【这一轮暂时没有做三个 preset 的本地持久化，想先确认当前画笔交互和整体方向是否符合预期。】

我这边已经做过基础检查和手工验证：
- TypeScript 检查通过
- ESLint 检查通过
- 相关单测通过
- build 通过
- 本地手工确认了 preset 切换、颜色/粗细应用、共享 slider 交互

目前我希望先让你快速预览一下这版关于画笔 preset 的行为是否符合你的想法。后面看看是不是要开始做持久化的保存部分