### PR TITLE
fix(size-slider): stop handled key propagation

### DIFF
--- a/packages/drawnix/src/components/size-slider.tsx
+++ b/packages/drawnix/src/components/size-slider.tsx
@@ -123,6 +123,21 @@ export const SizeSlider: React.FC<SliderProps> = ({
           if (disabled) {
             return;
           }
+          const isHandledKey =
+            event.key === 'ArrowLeft' ||
+            event.key === 'ArrowDown' ||
+            event.key === 'ArrowRight' ||
+            event.key === 'ArrowUp' ||
+            event.key === 'Home' ||
+            event.key === 'End';
+
+          if (!isHandledKey) {
+            return;
+          }
+
+          event.preventDefault();
+          event.stopPropagation();
+
           let nextValue = value;
 
           if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') {
@@ -139,7 +154,6 @@ export const SizeSlider: React.FC<SliderProps> = ({
           }
 
           if (nextValue !== value) {
-            event.preventDefault();
             updateValue(nextValue);
           }
         }}


### PR DESCRIPTION
这个 PR 修复了 `SizeSlider` 获取焦点后使用方向键调节时，会同时触发选中元素移动的问题。

问题原因是 `SizeSlider` 在处理方向键时只调用了 `preventDefault()`，但没有阻止事件继续冒泡到 board 层，因此在元素选中状态下，方向键会同时影响 slider 和元素位置。

这次修复中，我对 `SizeSlider` 接管的键盘事件做了统一拦截，包括：
- `ArrowLeft`
- `ArrowRight`
- `ArrowUp`
- `ArrowDown`
- `Home`
- `End`

处理方式是：
- 对这些键统一执行 `preventDefault()`
- 同时执行 `stopPropagation()`
- 然后再由 slider 内部更新数值

这样可以保证：
- slider 聚焦时，方向键只影响 slider
- 不再同时触发选中元素移动
- 即使 slider 已经处于边界值，键盘事件也不会继续传到 board 层

验证：
- TypeScript 检查通过
- ESLint 检查通过
- 本地手工复现并确认修复有效
