### PR TITLE
新增复制到剪贴板功能（SVG / PNG）

### DIFF
--- a/packages/drawnix/src/components/toolbar/popup-toolbar/more-options-button.tsx
+++ b/packages/drawnix/src/components/toolbar/popup-toolbar/more-options-button.tsx
@@ -9,6 +9,11 @@ import Menu from '../../menu/menu';
 import MenuItem from '../../menu/menu-item';
 import { useState } from 'react';
 import { getShortcutKey } from '../../../utils/common';
+import {
+  canCopySelectionAs,
+  copySelectionAsImage,
+  copySelectionAsSvg,
+} from '../../../utils/image';
 
 export type MoreOptionsButtonProps = {
   board: PlaitBoard;
@@ -20,6 +25,10 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({
   const { t } = useI18n();
   const container = PlaitBoard.getBoardContainer(board);
   const [menuOpen, setMenuOpen] = useState(false);
+  const canCopySvg = canCopySelectionAs('svg');
+  const canCopyPng = canCopySelectionAs('png');
+  const canCopyJpg = canCopySelectionAs('jpg');
+  const canCopyAny = canCopySvg || canCopyPng || canCopyJpg;
 
   return (
     <Popover
@@ -70,6 +79,52 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({
             aria-label={t('general.delete')}
           >
             {t('general.delete')}
+          </MenuItem>
+          <MenuItem
+            onSelect={() => undefined}
+            aria-label={t('general.copyToClipboard')}
+            disabled={!canCopyAny}
+            submenu={
+              <Menu
+                onSelect={() => {
+                  setMenuOpen(false);
+                }}
+              >
+                <MenuItem
+                  onSelect={() => {
+                    void copySelectionAsSvg(board).catch(() => undefined);
+                  }}
+                  disabled={!canCopySvg}
+                  aria-label={t('general.copyToClipboard.svg')}
+                >
+                  {t('general.copyToClipboard.svg')}
+                </MenuItem>
+                <MenuItem
+                  onSelect={() => {
+                    void copySelectionAsImage(board, 'png').catch(
+                      () => undefined
+                    );
+                  }}
+                  disabled={!canCopyPng}
+                  aria-label={t('general.copyToClipboard.png')}
+                >
+                  {t('general.copyToClipboard.png')}
+                </MenuItem>
+                <MenuItem
+                  onSelect={() => {
+                    void copySelectionAsImage(board, 'jpg').catch(
+                      () => undefined
+                    );
+                  }}
+                  disabled={!canCopyJpg}
+                  aria-label={t('general.copyToClipboard.jpg')}
+                >
+                  {t('general.copyToClipboard.jpg')}
+                </MenuItem>
+              </Menu>
+            }
+          >
+            {t('general.copyToClipboard')}
           </MenuItem>
         </Menu>
       </PopoverContent>

--- a/packages/drawnix/src/components/toolbar/popup-toolbar/more-options-button.tsx
+++ b/packages/drawnix/src/components/toolbar/popup-toolbar/more-options-button.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react';
 import { getShortcutKey } from '../../../utils/common';
 import {
   canCopySelectionAs,
-  copySelectionAsImage,
+  copySelectionAsPng,
   copySelectionAsSvg,
 } from '../../../utils/image';
 
@@ -27,8 +27,7 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({
   const [menuOpen, setMenuOpen] = useState(false);
   const canCopySvg = canCopySelectionAs('svg');
   const canCopyPng = canCopySelectionAs('png');
-  const canCopyJpg = canCopySelectionAs('jpg');
-  const canCopyAny = canCopySvg || canCopyPng || canCopyJpg;
+  const canCopyAny = canCopySvg || canCopyPng;
 
   return (
     <Popover
@@ -101,25 +100,21 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({
                 </MenuItem>
                 <MenuItem
                   onSelect={() => {
-                    void copySelectionAsImage(board, 'png').catch(
-                      () => undefined
-                    );
+                    void copySelectionAsPng(board).catch(() => undefined);
                   }}
                   disabled={!canCopyPng}
-                  aria-label={t('general.copyToClipboard.png')}
+                  aria-label={t('general.copyToClipboard.pngWithoutBackground')}
                 >
-                  {t('general.copyToClipboard.png')}
+                  {t('general.copyToClipboard.pngWithoutBackground')}
                 </MenuItem>
                 <MenuItem
                   onSelect={() => {
-                    void copySelectionAsImage(board, 'jpg').catch(
-                      () => undefined
-                    );
+                    void copySelectionAsPng(board, true).catch(() => undefined);
                   }}
-                  disabled={!canCopyJpg}
-                  aria-label={t('general.copyToClipboard.jpg')}
+                  disabled={!canCopyPng}
+                  aria-label={t('general.copyToClipboard.pngWithBackground')}
                 >
-                  {t('general.copyToClipboard.jpg')}
+                  {t('general.copyToClipboard.pngWithBackground')}
                 </MenuItem>
               </Menu>
             }

--- a/packages/drawnix/src/i18n/translations/ar.ts
+++ b/packages/drawnix/src/i18n/translations/ar.ts
@@ -68,6 +68,11 @@ const arTranslations: Translations = {
     "general.duplicate": "تكرار",
     "general.delete": "حذف",
 
+    "general.copyToClipboard": "نسخ إلى الحافظة",
+    "general.copyToClipboard.svg": "SVG",
+    "general.copyToClipboard.png": "PNG (بدون خلفية)",
+    "general.copyToClipboard.jpg": "PNG (مع خلفية)",
+
     // Language
     "language.switcher": "اللغة",
     "language.chinese": "中文",

--- a/packages/drawnix/src/i18n/translations/ar.ts
+++ b/packages/drawnix/src/i18n/translations/ar.ts
@@ -70,8 +70,8 @@ const arTranslations: Translations = {
 
     "general.copyToClipboard": "نسخ إلى الحافظة",
     "general.copyToClipboard.svg": "SVG",
-    "general.copyToClipboard.png": "PNG (بدون خلفية)",
-    "general.copyToClipboard.jpg": "PNG (مع خلفية)",
+    "general.copyToClipboard.pngWithoutBackground": "PNG (بدون خلفية)",
+    "general.copyToClipboard.pngWithBackground": "PNG (مع خلفية)",
 
     // Language
     "language.switcher": "اللغة",

--- a/packages/drawnix/src/i18n/translations/en.ts
+++ b/packages/drawnix/src/i18n/translations/en.ts
@@ -67,6 +67,10 @@ const enTranslations: Translations = {
   'general.moreOptions': 'More Options',
   'general.duplicate': 'Duplicate',
   'general.delete': 'Delete',
+  'general.copyToClipboard': 'Copy to Clipboard',
+  'general.copyToClipboard.svg': 'SVG',
+  'general.copyToClipboard.png': 'PNG (no background)',
+  'general.copyToClipboard.jpg': 'PNG (with background)',
 
   // Language
   'language.switcher': 'Language',

--- a/packages/drawnix/src/i18n/translations/en.ts
+++ b/packages/drawnix/src/i18n/translations/en.ts
@@ -69,8 +69,8 @@ const enTranslations: Translations = {
   'general.delete': 'Delete',
   'general.copyToClipboard': 'Copy to Clipboard',
   'general.copyToClipboard.svg': 'SVG',
-  'general.copyToClipboard.png': 'PNG (no background)',
-  'general.copyToClipboard.jpg': 'PNG (with background)',
+  'general.copyToClipboard.pngWithoutBackground': 'PNG (no background)',
+  'general.copyToClipboard.pngWithBackground': 'PNG (with background)',
 
   // Language
   'language.switcher': 'Language',

--- a/packages/drawnix/src/i18n/translations/ru.ts
+++ b/packages/drawnix/src/i18n/translations/ru.ts
@@ -68,6 +68,11 @@ const ruTranslations: Translations = {
   'general.duplicate': 'Дублировать',
   'general.delete': 'Удалить',
 
+  'general.copyToClipboard': 'Копировать в буфер обмена',
+  'general.copyToClipboard.svg': 'SVG',
+  'general.copyToClipboard.png': 'PNG (без фона)',
+  'general.copyToClipboard.jpg': 'PNG (с фоном)',
+
   // Language
   'language.switcher': 'Language',
   'language.chinese': '中文',

--- a/packages/drawnix/src/i18n/translations/ru.ts
+++ b/packages/drawnix/src/i18n/translations/ru.ts
@@ -70,8 +70,8 @@ const ruTranslations: Translations = {
 
   'general.copyToClipboard': 'Копировать в буфер обмена',
   'general.copyToClipboard.svg': 'SVG',
-  'general.copyToClipboard.png': 'PNG (без фона)',
-  'general.copyToClipboard.jpg': 'PNG (с фоном)',
+  'general.copyToClipboard.pngWithoutBackground': 'PNG (без фона)',
+  'general.copyToClipboard.pngWithBackground': 'PNG (с фоном)',
 
   // Language
   'language.switcher': 'Language',

--- a/packages/drawnix/src/i18n/translations/vi.ts
+++ b/packages/drawnix/src/i18n/translations/vi.ts
@@ -68,6 +68,11 @@ const viTranslations: Translations = {
     'general.duplicate': 'Nhân bản',
     'general.delete': 'Xóa',
 
+    'general.copyToClipboard': 'Sao chép vào bộ nhớ tạm',
+    'general.copyToClipboard.svg': 'SVG',
+    'general.copyToClipboard.png': 'PNG (không nền)',
+    'general.copyToClipboard.jpg': 'PNG (có nền)',
+
     // Language
     'language.switcher': 'Ngôn ngữ',
     'language.chinese': '中文',

--- a/packages/drawnix/src/i18n/translations/vi.ts
+++ b/packages/drawnix/src/i18n/translations/vi.ts
@@ -70,8 +70,8 @@ const viTranslations: Translations = {
 
     'general.copyToClipboard': 'Sao chép vào bộ nhớ tạm',
     'general.copyToClipboard.svg': 'SVG',
-    'general.copyToClipboard.png': 'PNG (không nền)',
-    'general.copyToClipboard.jpg': 'PNG (có nền)',
+    'general.copyToClipboard.pngWithoutBackground': 'PNG (không nền)',
+    'general.copyToClipboard.pngWithBackground': 'PNG (có nền)',
 
     // Language
     'language.switcher': 'Ngôn ngữ',

--- a/packages/drawnix/src/i18n/translations/zh.ts
+++ b/packages/drawnix/src/i18n/translations/zh.ts
@@ -68,6 +68,11 @@ const zhTranslations: Translations = {
   'general.duplicate': '复制',
   'general.delete': '删除',
 
+  'general.copyToClipboard': '复制到粘贴板',
+  'general.copyToClipboard.svg': 'SVG',
+  'general.copyToClipboard.png': 'PNG（无背景）',
+  'general.copyToClipboard.jpg': 'PNG（含背景）',
+
   // Language
   'language.switcher': 'Language',
   'language.chinese': '中文',

--- a/packages/drawnix/src/i18n/translations/zh.ts
+++ b/packages/drawnix/src/i18n/translations/zh.ts
@@ -70,8 +70,8 @@ const zhTranslations: Translations = {
 
   'general.copyToClipboard': '复制到粘贴板',
   'general.copyToClipboard.svg': 'SVG',
-  'general.copyToClipboard.png': 'PNG（无背景）',
-  'general.copyToClipboard.jpg': 'PNG（含背景）',
+  'general.copyToClipboard.pngWithoutBackground': 'PNG（无背景）',
+  'general.copyToClipboard.pngWithBackground': 'PNG（含背景）',
 
   // Language
   'language.switcher': 'Language',

--- a/packages/drawnix/src/i18n/translations/zh.ts
+++ b/packages/drawnix/src/i18n/translations/zh.ts
@@ -68,7 +68,7 @@ const zhTranslations: Translations = {
   'general.duplicate': '复制',
   'general.delete': '删除',
 
-  'general.copyToClipboard': '复制到粘贴板',
+  'general.copyToClipboard': '复制到剪贴板',
   'general.copyToClipboard.svg': 'SVG',
   'general.copyToClipboard.pngWithoutBackground': 'PNG（无背景）',
   'general.copyToClipboard.pngWithBackground': 'PNG（含背景）',

--- a/packages/drawnix/src/i18n/types.ts
+++ b/packages/drawnix/src/i18n/types.ts
@@ -73,8 +73,8 @@ export interface Translations {
   'general.delete': string;
   'general.copyToClipboard': string;
   'general.copyToClipboard.svg': string;
-  'general.copyToClipboard.png': string;
-  'general.copyToClipboard.jpg': string;
+  'general.copyToClipboard.pngWithoutBackground': string;
+  'general.copyToClipboard.pngWithBackground': string;
 
   // Language
   'language.switcher': string;

--- a/packages/drawnix/src/i18n/types.ts
+++ b/packages/drawnix/src/i18n/types.ts
@@ -71,6 +71,10 @@ export interface Translations {
   'general.moreOptions': string;
   'general.duplicate': string;
   'general.delete': string;
+  'general.copyToClipboard': string;
+  'general.copyToClipboard.svg': string;
+  'general.copyToClipboard.png': string;
+  'general.copyToClipboard.jpg': string;
 
   // Language
   'language.switcher': string;

--- a/packages/drawnix/src/utils/image.ts
+++ b/packages/drawnix/src/utils/image.ts
@@ -7,18 +7,15 @@ import { getBackgroundColor, isWhite } from './color';
 import { TRANSPARENT } from '../constants/color';
 
 type ClipboardImageFormat = 'svg' | 'png';
+type ExportElements = ReturnType<typeof getSelectedElements>;
 
 const CLIPBOARD_MIME_TYPES: Record<ClipboardImageFormat, string> = {
   svg: 'image/svg+xml',
   png: 'image/png',
 };
 
-const getSelectedClipboardElements = (board: PlaitBoard) => {
-  const selectedElements = getSelectedElements(board);
-  return selectedElements.length > 0 ? selectedElements : null;
-};
-
 const hasClipboardWriteSupport = () => {
+  // Keep the ClipboardItem check local until the shared helper also covers it.
   return (
     typeof navigator !== 'undefined' &&
     !!navigator.clipboard?.write &&
@@ -59,51 +56,38 @@ const writeBlobToClipboard = async (
   await navigator.clipboard.write([new ClipboardItem(item)]);
 };
 
-const getSelectedSvgBlob = async (board: PlaitBoard) => {
-  const selectedElements = getSelectedClipboardElements(board);
-  if (!selectedElements) {
-    return null;
-  }
+const getSvgBlob = async (board: PlaitBoard, elements?: ExportElements) => {
   const backgroundColor = getBackgroundColor(board);
   const svgData = await toSvgData(board, {
     fillStyle: isWhite(backgroundColor) ? TRANSPARENT : backgroundColor,
     padding: 20,
     ratio: 4,
-    elements: selectedElements,
+    elements,
     inlineStyleClassNames: '.plait-text-container',
     styleNames: ['position'],
   });
   return new Blob([svgData], { type: CLIPBOARD_MIME_TYPES.svg });
 };
 
-const getSelectedImageDataUrl = async (
+const getImageBlob = async (
   board: PlaitBoard,
-  isTransparent: boolean
+  isTransparent: boolean,
+  elements?: ExportElements
 ) => {
-  const selectedElements = getSelectedClipboardElements(board);
-  if (!selectedElements) {
-    return null;
-  }
   const backgroundColor = getBackgroundColor(board) || 'white';
-  return boardToImage(board, {
-    elements: selectedElements,
+  const imageDataUrl = await boardToImage(board, {
+    elements,
     fillStyle: isTransparent ? 'transparent' : backgroundColor,
   });
+  return imageDataUrl ? base64ToBlob(imageDataUrl) : null;
 };
 
 export const saveAsSvg = (board: PlaitBoard) => {
   const selectedElements = getSelectedElements(board);
-  const backgroundColor = getBackgroundColor(board);
-
-  return toSvgData(board, {
-    fillStyle: isWhite(backgroundColor) ? TRANSPARENT : backgroundColor,
-    padding: 20,
-    ratio: 4,
-    elements: selectedElements.length > 0 ? selectedElements : undefined,
-    inlineStyleClassNames: '.plait-text-container',
-    styleNames: ['position'],
-  }).then((svgData) => {
-    const blob = new Blob([svgData], { type: 'image/svg+xml' });
+  return getSvgBlob(
+    board,
+    selectedElements.length > 0 ? selectedElements : undefined
+  ).then((blob) => {
     const imageName = `drawnix-${new Date().getTime()}.svg`;
     download(blob, imageName);
   });
@@ -111,24 +95,28 @@ export const saveAsSvg = (board: PlaitBoard) => {
 
 export const saveAsImage = (board: PlaitBoard, isTransparent: boolean) => {
   const selectedElements = getSelectedElements(board);
-  const backgroundColor = getBackgroundColor(board) || 'white';
-  boardToImage(board, {
-    elements: selectedElements.length > 0 ? selectedElements : undefined,
-    fillStyle: isTransparent ? 'transparent' : backgroundColor,
-  }).then((image) => {
-    if (image) {
+  getImageBlob(
+    board,
+    isTransparent,
+    selectedElements.length > 0 ? selectedElements : undefined
+  ).then((imageBlob) => {
+    if (imageBlob) {
       const ext = isTransparent ? 'png' : 'jpg';
-      const pngImage = base64ToBlob(image);
       const imageName = `drawnix-${new Date().getTime()}.${ext}`;
-      download(pngImage, imageName);
+      download(imageBlob, imageName);
     }
   });
 };
 
 export const copySelectionAsSvg = async (board: PlaitBoard) => {
-  const blob = await getSelectedSvgBlob(board);
-  const pngDataUrl = await getSelectedImageDataUrl(board, true);
-  const pngBlob = pngDataUrl ? base64ToBlob(pngDataUrl) : null;
+  const selectedElements = getSelectedElements(board);
+  if (selectedElements.length === 0) {
+    return;
+  }
+  const [blob, pngBlob] = await Promise.all([
+    getSvgBlob(board, selectedElements),
+    getImageBlob(board, true, selectedElements),
+  ]);
   await writeBlobToClipboard('svg', blob, pngBlob);
 };
 
@@ -136,13 +124,21 @@ export const copySelectionAsPng = async (
   board: PlaitBoard,
   withBackground = false
 ) => {
-  const imageDataUrl = await getSelectedImageDataUrl(board, !withBackground);
-  if (!imageDataUrl) {
+  const selectedElements = getSelectedElements(board);
+  if (selectedElements.length === 0) {
+    return;
+  }
+  const imageBlob = await getImageBlob(
+    board,
+    !withBackground,
+    selectedElements
+  );
+  if (!imageBlob) {
     return;
   }
   // The clipboard only gets image/png. The background choice is controlled by
   // how the image is rendered before writing to the clipboard.
-  await writeBlobToClipboard('png', base64ToBlob(imageDataUrl));
+  await writeBlobToClipboard('png', imageBlob);
 };
 
 export const addImage = async (board: PlaitBoard) => {

--- a/packages/drawnix/src/utils/image.ts
+++ b/packages/drawnix/src/utils/image.ts
@@ -6,6 +6,94 @@ import { insertImage } from '../data/image';
 import { getBackgroundColor, isWhite } from './color';
 import { TRANSPARENT } from '../constants/color';
 
+type ClipboardImageFormat = 'svg' | 'png' | 'jpg';
+
+const CLIPBOARD_MIME_TYPES: Record<ClipboardImageFormat, string> = {
+  svg: 'image/svg+xml',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+};
+
+const getSelectedClipboardElements = (board: PlaitBoard) => {
+  const selectedElements = getSelectedElements(board);
+  return selectedElements.length > 0 ? selectedElements : null;
+};
+
+const hasClipboardWriteSupport = () => {
+  return (
+    typeof navigator !== 'undefined' &&
+    !!navigator.clipboard?.write &&
+    typeof ClipboardItem !== 'undefined'
+  );
+};
+
+const getClipboardItemSupports = () => {
+  const clipboardItemWithSupports = ClipboardItem as typeof ClipboardItem & {
+    supports?: (type: string) => boolean;
+  };
+  return clipboardItemWithSupports.supports;
+};
+
+export const canCopySelectionAs = (format: ClipboardImageFormat) => {
+  if (!hasClipboardWriteSupport()) {
+    return false;
+  }
+  // jpg is written as png with opaque background since clipboard doesn't support image/jpeg
+  const effectiveFormat = format === 'jpg' ? 'png' : format;
+  const supports = getClipboardItemSupports();
+  if (typeof supports === 'function') {
+    return supports(CLIPBOARD_MIME_TYPES[effectiveFormat]);
+  }
+  return effectiveFormat === 'png';
+};
+
+const writeBlobToClipboard = async (
+  format: ClipboardImageFormat,
+  blob: Blob | null,
+  fallbackPngBlob?: Blob | null
+) => {
+  if (!blob || !hasClipboardWriteSupport()) {
+    return;
+  }
+  const item: Record<string, Blob> = { [CLIPBOARD_MIME_TYPES[format]]: blob };
+  if (fallbackPngBlob) {
+    item[CLIPBOARD_MIME_TYPES.png] = fallbackPngBlob;
+  }
+  await navigator.clipboard.write([new ClipboardItem(item)]);
+};
+
+const getSelectedSvgBlob = async (board: PlaitBoard) => {
+  const selectedElements = getSelectedClipboardElements(board);
+  if (!selectedElements) {
+    return null;
+  }
+  const backgroundColor = getBackgroundColor(board);
+  const svgData = await toSvgData(board, {
+    fillStyle: isWhite(backgroundColor) ? TRANSPARENT : backgroundColor,
+    padding: 20,
+    ratio: 4,
+    elements: selectedElements,
+    inlineStyleClassNames: '.plait-text-container',
+    styleNames: ['position'],
+  });
+  return new Blob([svgData], { type: CLIPBOARD_MIME_TYPES.svg });
+};
+
+const getSelectedImageDataUrl = async (
+  board: PlaitBoard,
+  isTransparent: boolean
+) => {
+  const selectedElements = getSelectedClipboardElements(board);
+  if (!selectedElements) {
+    return null;
+  }
+  const backgroundColor = getBackgroundColor(board) || 'white';
+  return boardToImage(board, {
+    elements: selectedElements,
+    fillStyle: isTransparent ? 'transparent' : backgroundColor,
+  });
+};
+
 export const saveAsSvg = (board: PlaitBoard) => {
   const selectedElements = getSelectedElements(board);
   const backgroundColor = getBackgroundColor(board);
@@ -38,6 +126,28 @@ export const saveAsImage = (board: PlaitBoard, isTransparent: boolean) => {
       download(pngImage, imageName);
     }
   });
+};
+
+export const copySelectionAsSvg = async (board: PlaitBoard) => {
+  const blob = await getSelectedSvgBlob(board);
+  const pngDataUrl = await getSelectedImageDataUrl(board, true);
+  const pngBlob = pngDataUrl ? base64ToBlob(pngDataUrl) : null;
+  await writeBlobToClipboard('svg', blob, pngBlob);
+};
+
+export const copySelectionAsImage = async (
+  board: PlaitBoard,
+  format: Exclude<ClipboardImageFormat, 'svg'>
+) => {
+  const imageDataUrl = await getSelectedImageDataUrl(board, format === 'png');
+  if (!imageDataUrl) {
+    return;
+  }
+  // Both png and jpg are written as image/png to the clipboard.
+  // For jpg the image is rendered with an opaque background (isTransparent=false above),
+  // which gives the same effect as JPEG (no transparency) since the Clipboard API
+  // does not support image/jpeg in any browser.
+  await writeBlobToClipboard('png', base64ToBlob(imageDataUrl));
 };
 
 export const addImage = async (board: PlaitBoard) => {

--- a/packages/drawnix/src/utils/image.ts
+++ b/packages/drawnix/src/utils/image.ts
@@ -6,12 +6,11 @@ import { insertImage } from '../data/image';
 import { getBackgroundColor, isWhite } from './color';
 import { TRANSPARENT } from '../constants/color';
 
-type ClipboardImageFormat = 'svg' | 'png' | 'jpg';
+type ClipboardImageFormat = 'svg' | 'png';
 
 const CLIPBOARD_MIME_TYPES: Record<ClipboardImageFormat, string> = {
   svg: 'image/svg+xml',
   png: 'image/png',
-  jpg: 'image/jpeg',
 };
 
 const getSelectedClipboardElements = (board: PlaitBoard) => {
@@ -38,13 +37,11 @@ export const canCopySelectionAs = (format: ClipboardImageFormat) => {
   if (!hasClipboardWriteSupport()) {
     return false;
   }
-  // jpg is written as png with opaque background since clipboard doesn't support image/jpeg
-  const effectiveFormat = format === 'jpg' ? 'png' : format;
   const supports = getClipboardItemSupports();
   if (typeof supports === 'function') {
-    return supports(CLIPBOARD_MIME_TYPES[effectiveFormat]);
+    return supports(CLIPBOARD_MIME_TYPES[format]);
   }
-  return effectiveFormat === 'png';
+  return format === 'png';
 };
 
 const writeBlobToClipboard = async (
@@ -135,18 +132,16 @@ export const copySelectionAsSvg = async (board: PlaitBoard) => {
   await writeBlobToClipboard('svg', blob, pngBlob);
 };
 
-export const copySelectionAsImage = async (
+export const copySelectionAsPng = async (
   board: PlaitBoard,
-  format: Exclude<ClipboardImageFormat, 'svg'>
+  withBackground = false
 ) => {
-  const imageDataUrl = await getSelectedImageDataUrl(board, format === 'png');
+  const imageDataUrl = await getSelectedImageDataUrl(board, !withBackground);
   if (!imageDataUrl) {
     return;
   }
-  // Both png and jpg are written as image/png to the clipboard.
-  // For jpg the image is rendered with an opaque background (isTransparent=false above),
-  // which gives the same effect as JPEG (no transparency) since the Clipboard API
-  // does not support image/jpeg in any browser.
+  // The clipboard only gets image/png. The background choice is controlled by
+  // how the image is rendered before writing to the clipboard.
   await writeBlobToClipboard('png', base64ToBlob(imageDataUrl));
 };
 


### PR DESCRIPTION
## 变更说明

为选中元素新增“复制到剪贴板”能力，支持：
- SVG
- PNG（无背景）
- PNG（含背景）

## 改动内容

- 在更多操作菜单中新增复制到剪贴板子菜单
- 新增 SVG / PNG 两类复制逻辑
- SVG 复制时同时写入 PNG fallback
- 对齐内部函数命名与 UI 文案，去除残留的 JPG 语义
- 补充对应 i18n key 和多语言翻译


