### PR TITLE
ci: update base image and github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -23,13 +23,13 @@ jobs:
       # - run: npx nx-cloud start-ci-run --distribute-on="5 linux-medium-js" --stop-agents-after="e2e-ci"
 
       # Cache node_modules
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'npm'
 
       - run: npm ci
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@v5
 
       # 安装 Playwright 浏览器和依赖
       - name: Install Playwright

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,42 +5,45 @@ on:
     tags:
       - "*"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ${{ github.event.repository.name }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set TAG
-        run: echo TAG=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
-
-      - name: Publish ${{ matrix.svc }}
-        uses: docker/build-push-action@v3
+      - name: Publish version and latest tags
+        uses: docker/build-push-action@v7
         with:
           file: Dockerfile
           outputs: "type=registry,push=true"
           platforms: linux/amd64, linux/arm64
           tags: |
-            ghcr.io/${{ github.repository_owner }}/drawnix:latest
-            ghcr.io/${{ github.repository_owner }}/drawnix:${{ env.TAG }}
-            pubuzhixing/drawnix:${{ env.TAG }}
-            pubuzhixing/drawnix:latest
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install \
     && npm run build 
 
 
-FROM lipanski/docker-static-website:2.4.0
+FROM lipanski/docker-static-website:2.6.0
 
 WORKDIR /home/static
 


### PR DESCRIPTION
This pull request updates CI and publishing workflows, as well as the Dockerfile, to use the latest versions of GitHub Actions and Docker-related tools. The main goals are to improve security, maintain compatibility, and streamline the publishing process.

**Workflow and Docker toolchain upgrades:**

- **GitHub Actions version bumps:**
  - Updated `actions/checkout` from v4 to v6 in both `.github/workflows/ci.yml` and `.github/workflows/publish.yml`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL17-R17) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R8-R49)
  - Upgraded `actions/setup-node` from v3 to v6 and `nrwl/nx-set-shas` from v4 to v5 in `.github/workflows/ci.yml`.
  - Updated Docker-related actions (`docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/login-action`) to their latest major versions in `.github/workflows/publish.yml`.
  - Upgraded `docker/build-push-action` from v3 to v7 for publishing images.

**Publishing and permissions improvements:**

- **Enhanced permissions and environment setup:**
  - Added explicit `permissions` (read for contents, write for packages) and set `IMAGE_NAME` environment variable in the publish workflow for better security and flexibility.
  - Updated Docker image tags to use dynamic repository and ref names, improving maintainability and clarity.

**Base image update:**

- **Dockerfile update:**
  - Updated the base image for static website serving from `lipanski/docker-static-website:2.4.0` to `2.6.0` for improved security and features.