### PR TITLE
Fixes #397

### DIFF
--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.scss
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.scss
@@ -26,10 +26,6 @@
     display: block;
   }
 
-  .freehand-style-preset.tool-icon--selected .freehand-style-preset__preview-svg {
-    color: inherit;
-  }
-
   .freehand-style-preset__preview-base {
     fill: var(--color-surface-lowest);
   }

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.scss
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.scss
@@ -30,11 +30,6 @@
     fill: var(--color-surface-lowest);
   }
 
-  .freehand-style-preset__preview-ring-contrast,
-  .freehand-style-preset__preview-fill-contrast {
-    stroke: var(--color-gray-30);
-  }
-
   .freehand-style-setting {
     width: auto;
     min-width: auto;

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.scss
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.scss
@@ -15,24 +15,28 @@
     width: var(--default-icon-size);
     height: var(--default-icon-size);
     border-radius: 50%;
-    border: 1px solid var(--color-gray-40);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    background-color: var(--color-surface-lowest);
-
-    &.freehand-style-preset__preview--white {
-      box-shadow: inset 0 0 0 1px var(--color-gray-30);
-    }
   }
 
-  .freehand-style-preset__dot {
-    border-radius: 50%;
-    display: inline-flex;
+  .freehand-style-preset__preview-svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
 
-    &.freehand-style-preset__dot--white {
-      box-shadow: 0 0 0 1px var(--color-gray-30);
-    }
+  .freehand-style-preset.tool-icon--selected .freehand-style-preset__preview-svg {
+    color: inherit;
+  }
+
+  .freehand-style-preset__preview-base {
+    fill: var(--color-surface-lowest);
+  }
+
+  .freehand-style-preset__preview-ring-contrast,
+  .freehand-style-preset__preview-fill-contrast {
+    stroke: var(--color-gray-30);
   }
 
   .freehand-style-setting {

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.scss
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.scss
@@ -20,11 +20,19 @@
     align-items: center;
     justify-content: center;
     background-color: var(--color-surface-lowest);
+
+    &.freehand-style-preset__preview--white {
+      box-shadow: inset 0 0 0 1px var(--color-gray-30);
+    }
   }
 
   .freehand-style-preset__dot {
     border-radius: 50%;
     display: inline-flex;
+
+    &.freehand-style-preset__dot--white {
+      box-shadow: 0 0 0 1px var(--color-gray-30);
+    }
   }
 
   .freehand-style-setting {

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.spec.tsx
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.spec.tsx
@@ -32,6 +32,8 @@ jest.mock('../../../plugins/freehand/type', () => ({
 
 jest.mock('../../../utils/color', () => ({
   isNoColor: () => false,
+  isWhite: (color?: string) =>
+    color === '#FFFFFF' || color === '#ffffff',
 }));
 
 jest.mock('../../tool-button', () => ({

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.spec.tsx
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.spec.tsx
@@ -37,8 +37,14 @@ jest.mock('../../../utils/color', () => ({
 }));
 
 jest.mock('../../tool-button', () => ({
-  ToolButton: ({ children, ...props }: any) => (
-    <button type="button" aria-label={props['aria-label']}>
+  ToolButton: ({ children, className, selected, ...props }: any) => (
+    <button
+      type="button"
+      aria-label={props['aria-label']}
+      className={[className, selected ? 'tool-icon--selected' : '']
+        .filter(Boolean)
+        .join(' ')}
+    >
       {children}
     </button>
   ),
@@ -118,6 +124,7 @@ describe('FreehandStylePresetItem', () => {
     expect(base).not.toBeNull();
     expect(ring).not.toBeNull();
     expect(fill).not.toBeNull();
+    expect(container.querySelectorAll('circle')).toHaveLength(3);
     expect(base?.getAttribute('cx')).toBe('8');
     expect(base?.getAttribute('cy')).toBe('8');
     expect(base?.getAttribute('stroke')).toBe('none');
@@ -163,7 +170,7 @@ describe('FreehandStylePresetItem', () => {
     );
   });
 
-  it('renders gray contrast circles for white presets', () => {
+  it('renders a dedicated white contrast structure without the standard color ring', () => {
     const { container } = render(
       <FreehandStylePresetItem
         {...createProps({
@@ -176,11 +183,68 @@ describe('FreehandStylePresetItem', () => {
       />
     );
 
+    const contrastRing = container.querySelector(
+      '.freehand-style-preset__preview-ring-contrast'
+    );
+    const contrastFill = container.querySelector(
+      '.freehand-style-preset__preview-fill-contrast'
+    );
+
+    expect(container.querySelectorAll('circle')).toHaveLength(3);
+    expect(contrastRing).not.toBeNull();
+    expect(contrastRing?.getAttribute('stroke-width')).toBe('1');
+    expect(contrastFill).not.toBeNull();
+    expect(contrastFill?.getAttribute('stroke-width')).toBe('1');
+    expect(contrastFill?.getAttribute('fill')).toBe('#FFFFFF');
     expect(
-      container.querySelector('.freehand-style-preset__preview-ring-contrast')
-    ).not.toBeNull();
+      container.querySelector('.freehand-style-preset__preview-ring')
+    ).toBeNull();
     expect(
-      container.querySelector('.freehand-style-preset__preview-fill-contrast')
-    ).not.toBeNull();
+      container.querySelector('.freehand-style-preset__preview-fill')
+    ).toBeNull();
+  });
+
+  it('keeps the non-white outer ring color unchanged when selected', () => {
+    const { container } = render(
+      <FreehandStylePresetItem
+        {...createProps({
+          selected: true,
+        })}
+      />
+    );
+
+    const ring = container.querySelector('.freehand-style-preset__preview-ring');
+
+    expect(container.querySelector('.tool-icon--selected')).not.toBeNull();
+    expect(container.querySelectorAll('circle')).toHaveLength(3);
+    expect(ring?.getAttribute('stroke')).toBe('#FF4500');
+  });
+
+  it('keeps the white preset outer ring gray when selected', () => {
+    const { container } = render(
+      <FreehandStylePresetItem
+        {...createProps({
+          selected: true,
+          preset: {
+            id: 'preset-1',
+            color: '#FFFFFF',
+            size: 4,
+          },
+        })}
+      />
+    );
+
+    const contrastRing = container.querySelector(
+      '.freehand-style-preset__preview-ring-contrast'
+    );
+    const contrastFill = container.querySelector(
+      '.freehand-style-preset__preview-fill-contrast'
+    );
+
+    expect(container.querySelectorAll('circle')).toHaveLength(3);
+    expect(contrastRing?.getAttribute('stroke')).toBe('var(--color-gray-30)');
+    expect(contrastRing?.getAttribute('stroke-width')).toBe('1');
+    expect(contrastFill?.getAttribute('stroke')).toBe('var(--color-gray-30)');
+    expect(contrastFill?.getAttribute('stroke-width')).toBe('1');
   });
 });

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.spec.tsx
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.spec.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import {
+  FreehandStylePresetItem,
+  getFreehandPreviewRadius,
+  type FreehandStylePresetItemProps,
+} from './freehand-style-preset-item';
+
+jest.mock('../../../i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('@plait-board/react-board', () => ({
+  useBoard: () => ({
+    theme: {
+      themeColorMode: 'light',
+    },
+  }),
+}));
+
+jest.mock('../../../plugins/freehand/utils', () => ({
+  getFreehandDefaultStrokeColor: () => '#000000',
+}));
+
+jest.mock('../../../plugins/freehand/type', () => ({
+  FREEHAND_STROKE_WIDTH_STEP: 0.25,
+  MAX_FREEHAND_STROKE_WIDTH: 12,
+  MIN_FREEHAND_STROKE_WIDTH: 1,
+}));
+
+jest.mock('../../../utils/color', () => ({
+  isNoColor: () => false,
+}));
+
+jest.mock('../../tool-button', () => ({
+  ToolButton: ({ children, ...props }: any) => (
+    <button type="button" aria-label={props['aria-label']}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('../../popover/popover', () => ({
+  Popover: ({ children }: any) => <div>{children}</div>,
+  PopoverContent: ({ children }: any) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: any) => <>{children}</>,
+}));
+
+jest.mock('../../island', () => ({
+  Island: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('../../stack', () => ({
+  __esModule: true,
+  default: {
+    Col: ({ children }: any) => <div>{children}</div>,
+  },
+}));
+
+jest.mock('../../size-slider', () => ({
+  SizeSlider: () => null,
+}));
+
+jest.mock('../../color-picker', () => ({
+  ColorPicker: () => null,
+}));
+
+const createProps = (
+  overrides: Partial<FreehandStylePresetItemProps> = {}
+): FreehandStylePresetItemProps => ({
+  preset: {
+    id: 'preset-1',
+    color: '#FF4500',
+    size: 1,
+  },
+  selected: false,
+  container: null,
+  onSelect: jest.fn(),
+  onColorChange: jest.fn(),
+  onSizeChange: jest.fn(),
+  ...overrides,
+});
+
+describe('getFreehandPreviewRadius', () => {
+  it('maps the minimum stroke width to the minimum preview radius', () => {
+    expect(getFreehandPreviewRadius(1)).toBeCloseTo(2);
+  });
+
+  it('maps the maximum stroke width to the maximum preview radius', () => {
+    expect(getFreehandPreviewRadius(12)).toBeCloseTo(5.5);
+  });
+
+  it('clamps out-of-range stroke widths', () => {
+    expect(getFreehandPreviewRadius(0)).toBeCloseTo(2);
+    expect(getFreehandPreviewRadius(20)).toBeCloseTo(5.5);
+  });
+
+  it('increases monotonically across the supported stroke-width range', () => {
+    expect(getFreehandPreviewRadius(3)).toBeLessThan(getFreehandPreviewRadius(6));
+    expect(getFreehandPreviewRadius(6)).toBeLessThan(
+      getFreehandPreviewRadius(9)
+    );
+  });
+});
+
+describe('FreehandStylePresetItem', () => {
+  it('renders the preview ring and fill at the expected center point', () => {
+    const { container } = render(<FreehandStylePresetItem {...createProps()} />);
+
+    const base = container.querySelector('.freehand-style-preset__preview-base');
+    const ring = container.querySelector('.freehand-style-preset__preview-ring');
+    const fill = container.querySelector('.freehand-style-preset__preview-fill');
+
+    expect(base).not.toBeNull();
+    expect(ring).not.toBeNull();
+    expect(fill).not.toBeNull();
+    expect(base?.getAttribute('cx')).toBe('8');
+    expect(base?.getAttribute('cy')).toBe('8');
+    expect(base?.getAttribute('stroke')).toBe('none');
+    expect(ring?.getAttribute('cx')).toBe('8');
+    expect(ring?.getAttribute('cy')).toBe('8');
+    expect(fill?.getAttribute('cx')).toBe('8');
+    expect(fill?.getAttribute('cy')).toBe('8');
+    expect(fill?.getAttribute('stroke')).toBe('none');
+    expect(ring?.getAttribute('stroke')).toBe('#FF4500');
+  });
+
+  it('updates only the fill radius when the preset size changes', () => {
+    const { container, rerender } = render(
+      <FreehandStylePresetItem {...createProps()} />
+    );
+
+    const initialFill = container.querySelector(
+      '.freehand-style-preset__preview-fill'
+    );
+    const initialRadius = initialFill?.getAttribute('r');
+    const initialCenterX = initialFill?.getAttribute('cx');
+    const initialCenterY = initialFill?.getAttribute('cy');
+
+    rerender(
+      <FreehandStylePresetItem
+        {...createProps({
+          preset: {
+            id: 'preset-1',
+            color: '#FF4500',
+            size: 12,
+          },
+        })}
+      />
+    );
+
+    const nextFill = container.querySelector('.freehand-style-preset__preview-fill');
+
+    expect(nextFill?.getAttribute('cx')).toBe(initialCenterX);
+    expect(nextFill?.getAttribute('cy')).toBe(initialCenterY);
+    expect(nextFill?.getAttribute('r')).not.toBe(initialRadius);
+    expect(nextFill?.getAttribute('r')).toBe(
+      `${getFreehandPreviewRadius(12)}`
+    );
+  });
+
+  it('renders gray contrast circles for white presets', () => {
+    const { container } = render(
+      <FreehandStylePresetItem
+        {...createProps({
+          preset: {
+            id: 'preset-1',
+            color: '#FFFFFF',
+            size: 4,
+          },
+        })}
+      />
+    );
+
+    expect(
+      container.querySelector('.freehand-style-preset__preview-ring-contrast')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('.freehand-style-preset__preview-fill-contrast')
+    ).not.toBeNull();
+  });
+});

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.tsx
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.tsx
@@ -24,6 +24,28 @@ const formatSize = (value: number) => {
   return value.toFixed(2).replace(/\.?0+$/, '');
 };
 
+const FREEHAND_PREVIEW_VIEWBOX_SIZE = 16;
+const FREEHAND_PREVIEW_CENTER = FREEHAND_PREVIEW_VIEWBOX_SIZE / 2;
+const FREEHAND_PREVIEW_OUTER_RADIUS = 7;
+const FREEHAND_PREVIEW_MIN_RADIUS = 2;
+const FREEHAND_PREVIEW_MAX_RADIUS = 5.5;
+
+export const getFreehandPreviewRadius = (strokeWidth: number) => {
+  const clampedStrokeWidth = Math.min(
+    Math.max(strokeWidth, MIN_FREEHAND_STROKE_WIDTH),
+    MAX_FREEHAND_STROKE_WIDTH
+  );
+  const normalizedStrokeWidth =
+    (clampedStrokeWidth - MIN_FREEHAND_STROKE_WIDTH) /
+    (MAX_FREEHAND_STROKE_WIDTH - MIN_FREEHAND_STROKE_WIDTH);
+
+  return (
+    FREEHAND_PREVIEW_MIN_RADIUS +
+    normalizedStrokeWidth *
+      (FREEHAND_PREVIEW_MAX_RADIUS - FREEHAND_PREVIEW_MIN_RADIUS)
+  );
+};
+
 export interface FreehandStylePreset {
   id: string;
   color?: string;
@@ -53,6 +75,7 @@ export const FreehandStylePresetItem: React.FC<FreehandStylePresetItemProps> = (
   const swatchColor =
     preset.color || getFreehandDefaultStrokeColor(board.theme.themeColorMode);
   const shouldAddWhiteContrast = shouldAddWhitePresetContrast(swatchColor);
+  const previewRadius = getFreehandPreviewRadius(preset.size);
 
   React.useEffect(() => {
     if (!selected) {
@@ -90,24 +113,58 @@ export const FreehandStylePresetItem: React.FC<FreehandStylePresetItemProps> = (
             setOpen(false);
           }}
         >
-          <span
-            className={classNames('freehand-style-preset__preview', {
-              'freehand-style-preset__preview--white': shouldAddWhiteContrast,
-            })}
-            style={{
-              borderColor: swatchColor,
-            }}
-          >
-            <span
-              className={classNames('freehand-style-preset__dot', {
-                'freehand-style-preset__dot--white': shouldAddWhiteContrast,
-              })}
-              style={{
-                backgroundColor: swatchColor,
-                width: `${Math.min(Math.max(preset.size + 1, 4), 14)}px`,
-                height: `${Math.min(Math.max(preset.size + 1, 4), 14)}px`,
-              }}
-            />
+          <span className={classNames('freehand-style-preset__preview')}>
+            <svg
+              className="freehand-style-preset__preview-svg"
+              viewBox={`0 0 ${FREEHAND_PREVIEW_VIEWBOX_SIZE} ${FREEHAND_PREVIEW_VIEWBOX_SIZE}`}
+              aria-hidden="true"
+              focusable="false"
+            >
+              <circle
+                className="freehand-style-preset__preview-base"
+                cx={FREEHAND_PREVIEW_CENTER}
+                cy={FREEHAND_PREVIEW_CENTER}
+                r={FREEHAND_PREVIEW_OUTER_RADIUS + 0.5}
+                stroke="none"
+              />
+              {shouldAddWhiteContrast && (
+                <>
+                  <circle
+                    className="freehand-style-preset__preview-ring-contrast"
+                    cx={FREEHAND_PREVIEW_CENTER}
+                    cy={FREEHAND_PREVIEW_CENTER}
+                    r={FREEHAND_PREVIEW_OUTER_RADIUS}
+                    fill="none"
+                    strokeWidth={2}
+                  />
+                  <circle
+                    className="freehand-style-preset__preview-fill-contrast"
+                    cx={FREEHAND_PREVIEW_CENTER}
+                    cy={FREEHAND_PREVIEW_CENTER}
+                    r={previewRadius}
+                    fill="none"
+                    strokeWidth={1.5}
+                  />
+                </>
+              )}
+              <circle
+                className="freehand-style-preset__preview-ring"
+                cx={FREEHAND_PREVIEW_CENTER}
+                cy={FREEHAND_PREVIEW_CENTER}
+                r={FREEHAND_PREVIEW_OUTER_RADIUS}
+                fill="none"
+                stroke={swatchColor}
+                strokeWidth={1}
+              />
+              <circle
+                className="freehand-style-preset__preview-fill"
+                cx={FREEHAND_PREVIEW_CENTER}
+                cy={FREEHAND_PREVIEW_CENTER}
+                r={previewRadius}
+                fill={swatchColor}
+                stroke="none"
+              />
+            </svg>
           </span>
         </ToolButton>
       </PopoverTrigger>

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.tsx
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.tsx
@@ -14,10 +14,10 @@ import {
   MAX_FREEHAND_STROKE_WIDTH,
   MIN_FREEHAND_STROKE_WIDTH,
 } from '../../../plugins/freehand/type';
-import { isNoColor } from '../../../utils/color';
+import { isNoColor, isWhite } from '../../../utils/color';
 
 const shouldAddWhitePresetContrast = (color?: string) => {
-  return color?.toUpperCase() === '#FFFFFF';
+  return isWhite(color);
 };
 
 const formatSize = (value: number) => {

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.tsx
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.tsx
@@ -16,6 +16,10 @@ import {
 } from '../../../plugins/freehand/type';
 import { isNoColor } from '../../../utils/color';
 
+const shouldAddWhitePresetContrast = (color?: string) => {
+  return color?.toUpperCase() === '#FFFFFF';
+};
+
 const formatSize = (value: number) => {
   return value.toFixed(2).replace(/\.?0+$/, '');
 };
@@ -48,6 +52,7 @@ export const FreehandStylePresetItem: React.FC<FreehandStylePresetItemProps> = (
   const [open, setOpen] = React.useState(false);
   const swatchColor =
     preset.color || getFreehandDefaultStrokeColor(board.theme.themeColorMode);
+  const shouldAddWhiteContrast = shouldAddWhitePresetContrast(swatchColor);
 
   React.useEffect(() => {
     if (!selected) {
@@ -86,13 +91,17 @@ export const FreehandStylePresetItem: React.FC<FreehandStylePresetItemProps> = (
           }}
         >
           <span
-            className="freehand-style-preset__preview"
+            className={classNames('freehand-style-preset__preview', {
+              'freehand-style-preset__preview--white': shouldAddWhiteContrast,
+            })}
             style={{
               borderColor: swatchColor,
             }}
           >
             <span
-              className="freehand-style-preset__dot"
+              className={classNames('freehand-style-preset__dot', {
+                'freehand-style-preset__dot--white': shouldAddWhiteContrast,
+              })}
               style={{
                 backgroundColor: swatchColor,
                 width: `${Math.min(Math.max(preset.size + 1, 4), 14)}px`,

--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.tsx
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.tsx
@@ -16,10 +16,6 @@ import {
 } from '../../../plugins/freehand/type';
 import { isNoColor, isWhite } from '../../../utils/color';
 
-const shouldAddWhitePresetContrast = (color?: string) => {
-  return isWhite(color);
-};
-
 const formatSize = (value: number) => {
   return value.toFixed(2).replace(/\.?0+$/, '');
 };
@@ -29,6 +25,7 @@ const FREEHAND_PREVIEW_CENTER = FREEHAND_PREVIEW_VIEWBOX_SIZE / 2;
 const FREEHAND_PREVIEW_OUTER_RADIUS = 7;
 const FREEHAND_PREVIEW_MIN_RADIUS = 2;
 const FREEHAND_PREVIEW_MAX_RADIUS = 5.5;
+const FREEHAND_PREVIEW_CONTRAST_RING_COLOR = 'var(--color-gray-30)';
 
 export const getFreehandPreviewRadius = (strokeWidth: number) => {
   const clampedStrokeWidth = Math.min(
@@ -74,8 +71,9 @@ export const FreehandStylePresetItem: React.FC<FreehandStylePresetItemProps> = (
   const [open, setOpen] = React.useState(false);
   const swatchColor =
     preset.color || getFreehandDefaultStrokeColor(board.theme.themeColorMode);
-  const shouldAddWhiteContrast = shouldAddWhitePresetContrast(swatchColor);
+  const shouldAddWhitePresetContrast = isWhite(swatchColor);
   const previewRadius = getFreehandPreviewRadius(preset.size);
+  const isActive = selected || open;
 
   React.useEffect(() => {
     if (!selected) {
@@ -99,7 +97,7 @@ export const FreehandStylePresetItem: React.FC<FreehandStylePresetItemProps> = (
       <PopoverTrigger asChild>
         <ToolButton
           className={classNames('freehand-style-preset')}
-          selected={selected || open}
+          selected={isActive}
           type="button"
           size="small"
           visible={true}
@@ -113,7 +111,7 @@ export const FreehandStylePresetItem: React.FC<FreehandStylePresetItemProps> = (
             setOpen(false);
           }}
         >
-          <span className={classNames('freehand-style-preset__preview')}>
+          <span className="freehand-style-preset__preview">
             <svg
               className="freehand-style-preset__preview-svg"
               viewBox={`0 0 ${FREEHAND_PREVIEW_VIEWBOX_SIZE} ${FREEHAND_PREVIEW_VIEWBOX_SIZE}`}
@@ -127,7 +125,7 @@ export const FreehandStylePresetItem: React.FC<FreehandStylePresetItemProps> = (
                 r={FREEHAND_PREVIEW_OUTER_RADIUS + 0.5}
                 stroke="none"
               />
-              {shouldAddWhiteContrast && (
+              {shouldAddWhitePresetContrast ? (
                 <>
                   <circle
                     className="freehand-style-preset__preview-ring-contrast"
@@ -135,35 +133,40 @@ export const FreehandStylePresetItem: React.FC<FreehandStylePresetItemProps> = (
                     cy={FREEHAND_PREVIEW_CENTER}
                     r={FREEHAND_PREVIEW_OUTER_RADIUS}
                     fill="none"
-                    strokeWidth={2}
+                    stroke={FREEHAND_PREVIEW_CONTRAST_RING_COLOR}
+                    strokeWidth={1}
                   />
                   <circle
                     className="freehand-style-preset__preview-fill-contrast"
                     cx={FREEHAND_PREVIEW_CENTER}
                     cy={FREEHAND_PREVIEW_CENTER}
                     r={previewRadius}
+                    fill={swatchColor}
+                    stroke={FREEHAND_PREVIEW_CONTRAST_RING_COLOR}
+                    strokeWidth={1}
+                  />
+                </>
+              ) : (
+                <>
+                  <circle
+                    className="freehand-style-preset__preview-ring"
+                    cx={FREEHAND_PREVIEW_CENTER}
+                    cy={FREEHAND_PREVIEW_CENTER}
+                    r={FREEHAND_PREVIEW_OUTER_RADIUS}
                     fill="none"
-                    strokeWidth={1.5}
+                    stroke={swatchColor}
+                    strokeWidth={1}
+                  />
+                  <circle
+                    className="freehand-style-preset__preview-fill"
+                    cx={FREEHAND_PREVIEW_CENTER}
+                    cy={FREEHAND_PREVIEW_CENTER}
+                    r={previewRadius}
+                    fill={swatchColor}
+                    stroke="none"
                   />
                 </>
               )}
-              <circle
-                className="freehand-style-preset__preview-ring"
-                cx={FREEHAND_PREVIEW_CENTER}
-                cy={FREEHAND_PREVIEW_CENTER}
-                r={FREEHAND_PREVIEW_OUTER_RADIUS}
-                fill="none"
-                stroke={swatchColor}
-                strokeWidth={1}
-              />
-              <circle
-                className="freehand-style-preset__preview-fill"
-                cx={FREEHAND_PREVIEW_CENTER}
-                cy={FREEHAND_PREVIEW_CENTER}
-                r={previewRadius}
-                fill={swatchColor}
-                stroke="none"
-              />
             </svg>
           </span>
         </ToolButton>


### PR DESCRIPTION
这次除了 #397 里面的问题还发现了额外问题，也一并修复了。之前的笔触是横竖像素变化，会有对不齐同心圆的问题，这个发现之后看起来特别难受....
表现如下：上图是修复完的，下图是之前的 可以切换分支自己试试移动滑块 很明显
<img width="1469" height="931" alt="image" src="https://github.com/user-attachments/assets/d65070cc-3278-4177-bc37-20007d9a5071" />
现在逻辑是同心圆变换，并且对于白色的笔触额外有一个灰色的描边，总体视觉还是和之前的设计理念一样 外圈同色，内圈不描边（白色除外）
<img width="287" height="191" alt="image" src="https://github.com/user-attachments/assets/b944fe9f-6b6a-4333-a5d8-f9a53dc423ed" />
新增测试文件是为了给这次笔触预览渲染修复做回归保护，避免后续修改通用 SVG/toolbar 样式时再次把内圆描边或选中色串回去