### PR TITLE
fix(publish): streamline image tag handling by setting tag without 'v' prefix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set tag without v prefix
+        id: tag
+        run: echo "IMAGE_TAG=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
       - name: Publish version and latest tags
         uses: docker/build-push-action@v7
         with:
@@ -43,7 +47,7 @@ jobs:
           outputs: "type=registry,push=true"
           platforms: linux/amd64, linux/arm64
           tags: |
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.IMAGE_TAG }}
             ghcr.io/${{ github.repository }}:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.IMAGE_TAG }}
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
This pull request updates the Docker image publishing workflow to remove the leading "v" from version tags when publishing images. This ensures that Docker images are tagged with the version number only (e.g., "1.2.3" instead of "v1.2.3").

Docker image tagging improvements:

* Added a step to strip the "v" prefix from the Git tag and use the resulting value as the image tag (`IMAGE_TAG`) when publishing to both GitHub Container Registry and Docker Hub. (.github/workflows/publish.yml)
* Updated the Docker image tags in the publish step to use the new `IMAGE_TAG` value without the "v" prefix. (.github/workflows/publish.yml)