### PR TITLE
feat: add LaTeX block rendering support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "browser-fs-access": "^0.35.0",
         "classnames": "^2.5.1",
         "is-hotkey": "^0.2.0",
+        "katex": "^0.16.21",
         "laser-pen": "^1.0.1",
         "localforage": "^1.10.0",
         "mobile-detect": "^1.4.5",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "browser-fs-access": "^0.35.0",
     "classnames": "^2.5.1",
     "is-hotkey": "^0.2.0",
+    "katex": "^0.16.21",
     "laser-pen": "^1.0.1",
     "localforage": "^1.10.0",
     "mobile-detect": "^1.4.5",

--- a/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
+++ b/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
@@ -25,6 +25,7 @@ import { useContext } from 'react';
 import { MenuContentPropsContext } from '../../menu/common';
 import { EVENT } from '../../../constants';
 import { getShortcutKey } from '../../../utils/common';
+import { cacheLatexElementSizes } from '../../../plugins/with-latex';
 
 export const SaveToFile = () => {
   const board = useBoard();
@@ -57,6 +58,7 @@ export const OpenFile = () => {
     if (theme) {
       board.theme = theme;
     }
+    cacheLatexElementSizes(board, board.children);
     listRender.update(board.children, {
       board: board,
       parent: board,

--- a/packages/drawnix/src/components/ttd-dialog/ttd-dialog-output.tsx
+++ b/packages/drawnix/src/components/ttd-dialog/ttd-dialog-output.tsx
@@ -4,6 +4,7 @@ import { withDraw } from '@plait/draw';
 import { withCommonPlugin } from '../../plugins/with-common';
 import { Board, Wrapper } from '@plait-board/react-board';
 import { MindThemeColors, withMind } from '@plait/mind';
+import { withLatexBlockRendering } from '../../plugins/with-latex';
 
 const ErrorComp = ({ error }: { error: string }) => {
   return (
@@ -27,7 +28,13 @@ export const TTDDialogOutput = ({
   value,
   loaded,
 }: TTDDialogOutputProps) => {
-  const plugins: PlaitPlugin[] = [withDraw, withMind, withGroup, withCommonPlugin];
+  const plugins: PlaitPlugin[] = [
+    withDraw,
+    withMind,
+    withGroup,
+    withCommonPlugin,
+    withLatexBlockRendering,
+  ];
   const options = {
     readonly: true,
     hideScrollbar: false,

--- a/packages/drawnix/src/drawnix.tsx
+++ b/packages/drawnix/src/drawnix.tsx
@@ -41,6 +41,7 @@ import { I18nProvider } from './i18n';
 import { Tutorial } from './components/tutorial';
 import { LASER_POINTER_CLASS_NAME } from './utils/laser-pointer';
 import { DEFAULT_FREEHAND_PRESETS } from './plugins/freehand/presets';
+import { withLatexBlockRendering } from './plugins/with-latex';
 
 export type DrawnixProps = {
   value: PlaitElement[];
@@ -113,6 +114,7 @@ export const Drawnix: React.FC<DrawnixProps> = ({
     withFreehand,
     buildPencilPlugin(updateAppState),
     buildTextLinkPlugin(updateAppState),
+    withLatexBlockRendering,
   ];
 
   const containerRef = useRef<HTMLDivElement>(null);

--- a/packages/drawnix/src/plugins/with-latex.ts
+++ b/packages/drawnix/src/plugins/with-latex.ts
@@ -6,13 +6,19 @@ import {
 } from '@plait/common';
 import {
   PlaitBoard,
+  RectangleClient,
   type ClipboardData,
   type PlaitElement,
   type PlaitPlugin,
   type Point,
   type WritableClipboardOperationType,
 } from '@plait/core';
-import { DrawTransforms, PlaitDrawElement } from '@plait/draw';
+import {
+  DrawTransforms,
+  MIN_TEXT_WIDTH,
+  PlaitDrawElement,
+  ShapeDefaultSpace,
+} from '@plait/draw';
 import {
   MindElement,
   NodeSpace,
@@ -29,6 +35,8 @@ const PATCHED_TEXT_MANAGES = new WeakSet<TextManage>();
 const BOARDS_WITH_LATEX_CACHE = new WeakSet<PlaitBoard>();
 const PENDING_LATEX_SIZE_CACHES = new WeakSet<PlaitBoard>();
 const PENDING_TEXT_MANAGE_BINDINGS = new WeakSet<PlaitBoard>();
+const PENDING_TEXT_MANAGE_EXIT_REFRESHES = new WeakSet<TextManage>();
+const BOARDS_UPDATING_LATEX_TEXT_SIZE = new WeakSet<PlaitBoard>();
 
 export const cacheLatexElementSizes = (
   board: PlaitBoard,
@@ -62,8 +70,12 @@ export const withLatexBlockRendering: PlaitPlugin = (board) => {
 
   const { apply, insertFragment } = board;
   board.apply = (operation) => {
+    const shouldScheduleLatexRefresh =
+      !BOARDS_UPDATING_LATEX_TEXT_SIZE.has(board);
     apply(operation);
-    scheduleLatexElementSizeCaching(board);
+    if (shouldScheduleLatexRefresh) {
+      scheduleLatexElementSizeCaching(board);
+    }
     scheduleTextManageBinding(board);
   };
 
@@ -94,24 +106,22 @@ const cacheLatexElementSize = (
       includeSourceSize,
       shouldClearMissingLatex
     );
-    element.children.forEach((child) =>
-      (hasLatex =
-        cacheLatexElementSize(
-          board,
-          child,
-          includeSourceSize,
-          shouldClearMissingLatex
-        ) || hasLatex)
+    element.children.forEach(
+      (child) =>
+        (hasLatex =
+          cacheLatexElementSize(
+            board,
+            child,
+            includeSourceSize,
+            shouldClearMissingLatex
+          ) || hasLatex)
     );
     return hasLatex;
   }
 
   let hasLatex = false;
   findTextElements(element).forEach((textElement) => {
-    if (
-      hasLatexBlocksInTextElement(textElement) ||
-      shouldClearMissingLatex
-    ) {
+    if (hasLatexBlocksInTextElement(textElement) || shouldClearMissingLatex) {
       hasLatex =
         cacheDefaultLatexSize(board, textElement, includeSourceSize) ||
         hasLatex;
@@ -128,8 +138,17 @@ const scheduleLatexElementSizeCaching = (board: PlaitBoard) => {
   PENDING_LATEX_SIZE_CACHES.add(board);
   setTimeout(() => {
     PENDING_LATEX_SIZE_CACHES.delete(board);
-    cacheLatexElementSizes(board);
+    refreshLatexElementsAfterApply(board);
   }, 0);
+};
+
+const refreshLatexElementsAfterApply = (board: PlaitBoard) => {
+  const isTextEditing = PlaitBoard.hasBeenTextEditing(board);
+  cacheLatexElementSizes(board);
+  if (!isTextEditing) {
+    resizeAutoSizeTextElements(board, board.children);
+  }
+  updateTextManageRectangles(board, board.children);
 };
 
 const scheduleTextManageBinding = (board: PlaitBoard) => {
@@ -182,11 +201,39 @@ const bindLatexTextManageExit = (board: PlaitBoard, element: PlaitElement) => {
       }, exitEdit);
     };
     PATCHED_TEXT_MANAGES.add(textManage);
+    scheduleActiveTextManageExitRefresh(board, element, textManage);
   });
 
   if (MindElement.isMindElement(board, element)) {
     element.children.forEach((child) => bindLatexTextManageExit(board, child));
   }
+};
+
+const scheduleActiveTextManageExitRefresh = (
+  board: PlaitBoard,
+  editedElement: PlaitElement,
+  textManage: TextManage
+) => {
+  // A newly created text element can enter edit mode before this plugin binds
+  // textManage.edit, so watch the active edit once and refresh after it exits.
+  if (
+    !textManage.isEditing ||
+    PENDING_TEXT_MANAGE_EXIT_REFRESHES.has(textManage)
+  ) {
+    return;
+  }
+
+  PENDING_TEXT_MANAGE_EXIT_REFRESHES.add(textManage);
+  const refreshWhenEditExits = () => {
+    if (textManage.isEditing) {
+      setTimeout(refreshWhenEditExits, 50);
+      return;
+    }
+
+    PENDING_TEXT_MANAGE_EXIT_REFRESHES.delete(textManage);
+    schedulePostEditRefresh(board, editedElement);
+  };
+  setTimeout(refreshWhenEditExits, 50);
 };
 
 const prepareLatexTextManageEdit = (
@@ -275,9 +322,35 @@ const resizeAutoSizeTextElement = (
     fontFamily: DEFAULT_FONT_FAMILY,
     fontSize: 14,
   });
-  if (size) {
-    DrawTransforms.setTextSize(board, element, size.width, size.height);
+  if (
+    size &&
+    !hasCurrentAutoSizeTextElementSize(element, size.width, size.height)
+  ) {
+    BOARDS_UPDATING_LATEX_TEXT_SIZE.add(board);
+    try {
+      DrawTransforms.setTextSize(board, element, size.width, size.height);
+    } finally {
+      BOARDS_UPDATING_LATEX_TEXT_SIZE.delete(board);
+    }
   }
+};
+
+const hasCurrentAutoSizeTextElementSize = (
+  element: PlaitElement,
+  width: number,
+  height: number
+) => {
+  if (!PlaitDrawElement.isText(element)) {
+    return false;
+  }
+
+  const rectangle = RectangleClient.getRectangleByPoints(element.points);
+  const targetWidth =
+    Math.max(width, MIN_TEXT_WIDTH) + ShapeDefaultSpace.rectangleAndText * 2;
+  return (
+    Math.abs(rectangle.width - targetWidth) < 1 &&
+    Math.abs(rectangle.height - height) < 1
+  );
 };
 
 const findCurrentElement = (

--- a/packages/drawnix/src/plugins/with-latex.ts
+++ b/packages/drawnix/src/plugins/with-latex.ts
@@ -1,5 +1,18 @@
-import { DEFAULT_FONT_FAMILY, type ParagraphElement } from '@plait/common';
-import { PlaitBoard, type PlaitElement, type PlaitPlugin } from '@plait/core';
+import {
+  DEFAULT_FONT_FAMILY,
+  getTextManages,
+  type ParagraphElement,
+  type TextManage,
+} from '@plait/common';
+import {
+  PlaitBoard,
+  type ClipboardData,
+  type PlaitElement,
+  type PlaitPlugin,
+  type Point,
+  type WritableClipboardOperationType,
+} from '@plait/core';
+import { DrawTransforms, PlaitDrawElement } from '@plait/draw';
 import {
   MindElement,
   NodeSpace,
@@ -8,7 +21,11 @@ import {
 import {
   cacheLatexTextElementSize,
   findTextElements,
+  hasLatexBlocksInTextElement,
+  measureLatexTextElement,
 } from '@plait-board/react-text';
+
+const PATCHED_TEXT_MANAGES = new WeakSet<TextManage>();
 
 export const cacheLatexElementSizes = (
   board: PlaitBoard,
@@ -22,11 +39,22 @@ export const cacheLatexElementSizes = (
 
 export const withLatexBlockRendering: PlaitPlugin = (board) => {
   cacheLatexElementSizes(board);
+  scheduleTextManageBinding(board);
 
-  const { apply } = board;
+  const { apply, insertFragment } = board;
   board.apply = (operation) => {
     apply(operation);
     cacheLatexElementSizes(board);
+    scheduleTextManageBinding(board);
+  };
+
+  board.insertFragment = (
+    clipboardData: ClipboardData | null,
+    targetPoint: Point,
+    operationType?: WritableClipboardOperationType
+  ) => {
+    insertFragment(clipboardData, targetPoint, operationType);
+    schedulePostInsertRefresh(board);
   };
 
   return board;
@@ -37,6 +65,8 @@ const cacheLatexElementSize = (
   element: PlaitElement,
   includeSourceSize: boolean
 ) => {
+  bindLatexTextManageExit(board, element);
+
   if (MindElement.isMindElement(board, element)) {
     cacheMindElementLatexSize(board, element, includeSourceSize);
     element.children.forEach((child) =>
@@ -50,12 +80,182 @@ const cacheLatexElementSize = (
   });
 };
 
+const scheduleTextManageBinding = (board: PlaitBoard) => {
+  setTimeout(() => {
+    board.children.forEach((element) => {
+      bindLatexTextManageExit(board, element);
+    });
+  }, 0);
+};
+
+const schedulePostInsertRefresh = (board: PlaitBoard) => {
+  setTimeout(() => {
+    refreshRenderedLatexElements(board, board.children);
+  }, 0);
+};
+
+const updateTextManageRectangles = (
+  board: PlaitBoard,
+  elements: PlaitElement[]
+) => {
+  elements.forEach((element) => {
+    getTextManages(element).forEach((textManage) =>
+      textManage.updateRectangle()
+    );
+
+    if (MindElement.isMindElement(board, element)) {
+      updateTextManageRectangles(board, element.children);
+    }
+  });
+};
+
+const bindLatexTextManageExit = (board: PlaitBoard, element: PlaitElement) => {
+  getTextManages(element).forEach((textManage) => {
+    if (PATCHED_TEXT_MANAGES.has(textManage)) {
+      return;
+    }
+
+    const edit = textManage.edit.bind(textManage);
+    textManage.edit = (callback, exitEdit) => {
+      prepareLatexTextManageEdit(board, element);
+      return edit(() => {
+        callback?.();
+        schedulePostEditRefresh(board, element);
+      }, exitEdit);
+    };
+    PATCHED_TEXT_MANAGES.add(textManage);
+  });
+
+  if (MindElement.isMindElement(board, element)) {
+    element.children.forEach((child) => bindLatexTextManageExit(board, child));
+  }
+};
+
+const prepareLatexTextManageEdit = (
+  board: PlaitBoard,
+  editedElement: PlaitElement
+) => {
+  const element = findCurrentElement(board, editedElement);
+  if (!element) {
+    return;
+  }
+
+  cacheLatexElementSize(board, element, true);
+  updateTextManageRectangles(board, [element]);
+};
+
+const schedulePostEditRefresh = (
+  board: PlaitBoard,
+  editedElement: PlaitElement
+) => {
+  setTimeout(() => {
+    const element = findCurrentElement(board, editedElement);
+    if (!element) {
+      return;
+    }
+
+    refreshRenderedLatexElements(board, [element]);
+  }, 0);
+};
+
+const refreshRenderedLatexElements = (
+  board: PlaitBoard,
+  elements: PlaitElement[]
+) => {
+  cacheRenderedLatexElementSizes(board, elements);
+  resizeAutoSizeTextElements(board, elements);
+  updateTextManageRectangles(board, elements);
+};
+
+const cacheRenderedLatexElementSizes = (
+  board: PlaitBoard,
+  elements: PlaitElement[]
+) => {
+  elements.forEach((element) => {
+    cacheLatexElementSize(board, element, false);
+  });
+};
+
+const resizeAutoSizeTextElements = (
+  board: PlaitBoard,
+  elements: PlaitElement[]
+) => {
+  elements.forEach((element) => {
+    resizeAutoSizeTextElement(board, element);
+
+    if (MindElement.isMindElement(board, element)) {
+      resizeAutoSizeTextElements(board, element.children);
+    }
+  });
+};
+
+const resizeAutoSizeTextElement = (
+  board: PlaitBoard,
+  element: PlaitElement
+) => {
+  if (
+    !PlaitDrawElement.isText(element) ||
+    !element.autoSize ||
+    !element.text ||
+    !hasLatexBlocksInTextElement(element.text)
+  ) {
+    return;
+  }
+
+  const text = element.text;
+  const size = measureLatexTextElement(text, {
+    fontFamily: DEFAULT_FONT_FAMILY,
+    fontSize: 14,
+  });
+  if (size) {
+    DrawTransforms.setTextSize(board, element, size.width, size.height);
+  }
+};
+
+const findCurrentElement = (
+  board: PlaitBoard,
+  target: PlaitElement
+): PlaitElement | null => {
+  const targetId = target.id;
+  if (!targetId) {
+    return target;
+  }
+
+  let matchedElement: PlaitElement | null = null;
+  const visit = (elements: PlaitElement[]) => {
+    for (const element of elements) {
+      if (element.id === targetId) {
+        matchedElement = element;
+        return;
+      }
+      if (MindElement.isMindElement(board, element)) {
+        visit(element.children);
+        if (matchedElement) {
+          return;
+        }
+      }
+    }
+  };
+
+  visit(board.children);
+  return matchedElement;
+};
+
 const cacheMindElementLatexSize = (
   board: PlaitBoard,
   element: MindElement,
+  _includeSourceSize: boolean
+) => {
+  cacheMindTopicLatexSize(board, element, element.data.topic, false);
+};
+
+const cacheMindTopicLatexSize = (
+  board: PlaitBoard,
+  element: MindElement,
+  topic: ParagraphElement,
   includeSourceSize: boolean
 ) => {
-  cacheLatexTextElementSize(board, element.data.topic, {
+  cacheLatexTextElementSize(board, topic, {
     fontFamily: DEFAULT_FONT_FAMILY,
     fontSize: getDefaultFontSizeForMindElement(element),
     includeSourceSize,

--- a/packages/drawnix/src/plugins/with-latex.ts
+++ b/packages/drawnix/src/plugins/with-latex.ts
@@ -1,0 +1,76 @@
+import { DEFAULT_FONT_FAMILY, type ParagraphElement } from '@plait/common';
+import { PlaitBoard, type PlaitElement, type PlaitPlugin } from '@plait/core';
+import {
+  MindElement,
+  NodeSpace,
+  getDefaultFontSizeForMindElement,
+} from '@plait/mind';
+import {
+  cacheLatexTextElementSize,
+  findTextElements,
+} from '@plait-board/react-text';
+
+export const cacheLatexElementSizes = (
+  board: PlaitBoard,
+  elements: PlaitElement[] = board.children
+) => {
+  const includeSourceSize = PlaitBoard.hasBeenTextEditing(board);
+  elements.forEach((element) => {
+    cacheLatexElementSize(board, element, includeSourceSize);
+  });
+};
+
+export const withLatexBlockRendering: PlaitPlugin = (board) => {
+  cacheLatexElementSizes(board);
+
+  const { apply } = board;
+  board.apply = (operation) => {
+    apply(operation);
+    cacheLatexElementSizes(board);
+  };
+
+  return board;
+};
+
+const cacheLatexElementSize = (
+  board: PlaitBoard,
+  element: PlaitElement,
+  includeSourceSize: boolean
+) => {
+  if (MindElement.isMindElement(board, element)) {
+    cacheMindElementLatexSize(board, element, includeSourceSize);
+    element.children.forEach((child) =>
+      cacheLatexElementSize(board, child, includeSourceSize)
+    );
+    return;
+  }
+
+  findTextElements(element).forEach((textElement) => {
+    cacheDefaultLatexSize(board, textElement, includeSourceSize);
+  });
+};
+
+const cacheMindElementLatexSize = (
+  board: PlaitBoard,
+  element: MindElement,
+  includeSourceSize: boolean
+) => {
+  cacheLatexTextElementSize(board, element.data.topic, {
+    fontFamily: DEFAULT_FONT_FAMILY,
+    fontSize: getDefaultFontSizeForMindElement(element),
+    includeSourceSize,
+    maxWidth: NodeSpace.getTopicMaxDynamicWidth(board as any, element),
+  });
+};
+
+const cacheDefaultLatexSize = (
+  board: PlaitBoard,
+  textElement: ParagraphElement,
+  includeSourceSize: boolean
+) => {
+  cacheLatexTextElementSize(board, textElement, {
+    fontFamily: DEFAULT_FONT_FAMILY,
+    fontSize: 14,
+    includeSourceSize,
+  });
+};

--- a/packages/drawnix/src/plugins/with-latex.ts
+++ b/packages/drawnix/src/plugins/with-latex.ts
@@ -26,15 +26,34 @@ import {
 } from '@plait-board/react-text';
 
 const PATCHED_TEXT_MANAGES = new WeakSet<TextManage>();
+const BOARDS_WITH_LATEX_CACHE = new WeakSet<PlaitBoard>();
+const PENDING_LATEX_SIZE_CACHES = new WeakSet<PlaitBoard>();
+const PENDING_TEXT_MANAGE_BINDINGS = new WeakSet<PlaitBoard>();
 
 export const cacheLatexElementSizes = (
   board: PlaitBoard,
   elements: PlaitElement[] = board.children
 ) => {
   const includeSourceSize = PlaitBoard.hasBeenTextEditing(board);
+  const shouldClearMissingLatex = BOARDS_WITH_LATEX_CACHE.has(board);
+  let hasLatex = false;
   elements.forEach((element) => {
-    cacheLatexElementSize(board, element, includeSourceSize);
+    hasLatex =
+      cacheLatexElementSize(
+        board,
+        element,
+        includeSourceSize,
+        shouldClearMissingLatex
+      ) || hasLatex;
   });
+  if (elements === board.children) {
+    if (hasLatex) {
+      BOARDS_WITH_LATEX_CACHE.add(board);
+    } else {
+      BOARDS_WITH_LATEX_CACHE.delete(board);
+    }
+  }
+  return hasLatex;
 };
 
 export const withLatexBlockRendering: PlaitPlugin = (board) => {
@@ -44,7 +63,7 @@ export const withLatexBlockRendering: PlaitPlugin = (board) => {
   const { apply, insertFragment } = board;
   board.apply = (operation) => {
     apply(operation);
-    cacheLatexElementSizes(board);
+    scheduleLatexElementSizeCaching(board);
     scheduleTextManageBinding(board);
   };
 
@@ -63,25 +82,64 @@ export const withLatexBlockRendering: PlaitPlugin = (board) => {
 const cacheLatexElementSize = (
   board: PlaitBoard,
   element: PlaitElement,
-  includeSourceSize: boolean
+  includeSourceSize: boolean,
+  shouldClearMissingLatex: boolean
 ) => {
   bindLatexTextManageExit(board, element);
 
   if (MindElement.isMindElement(board, element)) {
-    cacheMindElementLatexSize(board, element, includeSourceSize);
-    element.children.forEach((child) =>
-      cacheLatexElementSize(board, child, includeSourceSize)
+    let hasLatex = cacheMindElementLatexSize(
+      board,
+      element,
+      includeSourceSize,
+      shouldClearMissingLatex
     );
+    element.children.forEach((child) =>
+      (hasLatex =
+        cacheLatexElementSize(
+          board,
+          child,
+          includeSourceSize,
+          shouldClearMissingLatex
+        ) || hasLatex)
+    );
+    return hasLatex;
+  }
+
+  let hasLatex = false;
+  findTextElements(element).forEach((textElement) => {
+    if (
+      hasLatexBlocksInTextElement(textElement) ||
+      shouldClearMissingLatex
+    ) {
+      hasLatex =
+        cacheDefaultLatexSize(board, textElement, includeSourceSize) ||
+        hasLatex;
+    }
+  });
+  return hasLatex;
+};
+
+const scheduleLatexElementSizeCaching = (board: PlaitBoard) => {
+  if (PENDING_LATEX_SIZE_CACHES.has(board)) {
     return;
   }
 
-  findTextElements(element).forEach((textElement) => {
-    cacheDefaultLatexSize(board, textElement, includeSourceSize);
-  });
+  PENDING_LATEX_SIZE_CACHES.add(board);
+  setTimeout(() => {
+    PENDING_LATEX_SIZE_CACHES.delete(board);
+    cacheLatexElementSizes(board);
+  }, 0);
 };
 
 const scheduleTextManageBinding = (board: PlaitBoard) => {
+  if (PENDING_TEXT_MANAGE_BINDINGS.has(board)) {
+    return;
+  }
+
+  PENDING_TEXT_MANAGE_BINDINGS.add(board);
   setTimeout(() => {
+    PENDING_TEXT_MANAGE_BINDINGS.delete(board);
     board.children.forEach((element) => {
       bindLatexTextManageExit(board, element);
     });
@@ -140,7 +198,12 @@ const prepareLatexTextManageEdit = (
     return;
   }
 
-  cacheLatexElementSize(board, element, true);
+  cacheLatexElementSize(
+    board,
+    element,
+    true,
+    BOARDS_WITH_LATEX_CACHE.has(board)
+  );
   updateTextManageRectangles(board, [element]);
 };
 
@@ -172,7 +235,12 @@ const cacheRenderedLatexElementSizes = (
   elements: PlaitElement[]
 ) => {
   elements.forEach((element) => {
-    cacheLatexElementSize(board, element, false);
+    cacheLatexElementSize(
+      board,
+      element,
+      false,
+      BOARDS_WITH_LATEX_CACHE.has(board)
+    );
   });
 };
 
@@ -244,9 +312,16 @@ const findCurrentElement = (
 const cacheMindElementLatexSize = (
   board: PlaitBoard,
   element: MindElement,
-  _includeSourceSize: boolean
+  _includeSourceSize: boolean,
+  shouldClearMissingLatex: boolean
 ) => {
-  cacheMindTopicLatexSize(board, element, element.data.topic, false);
+  if (
+    hasLatexBlocksInTextElement(element.data.topic) ||
+    shouldClearMissingLatex
+  ) {
+    return cacheMindTopicLatexSize(board, element, element.data.topic, false);
+  }
+  return false;
 };
 
 const cacheMindTopicLatexSize = (
@@ -255,7 +330,7 @@ const cacheMindTopicLatexSize = (
   topic: ParagraphElement,
   includeSourceSize: boolean
 ) => {
-  cacheLatexTextElementSize(board, topic, {
+  return cacheLatexTextElementSize(board, topic, {
     fontFamily: DEFAULT_FONT_FAMILY,
     fontSize: getDefaultFontSizeForMindElement(element),
     includeSourceSize,
@@ -268,7 +343,7 @@ const cacheDefaultLatexSize = (
   textElement: ParagraphElement,
   includeSourceSize: boolean
 ) => {
-  cacheLatexTextElementSize(board, textElement, {
+  return cacheLatexTextElementSize(board, textElement, {
     fontFamily: DEFAULT_FONT_FAMILY,
     fontSize: 14,
     includeSourceSize,

--- a/packages/drawnix/src/plugins/with-latex.ts
+++ b/packages/drawnix/src/plugins/with-latex.ts
@@ -29,7 +29,9 @@ import {
   findTextElements,
   hasLatexBlocksInTextElement,
   measureLatexTextElement,
+  parseLatexBlocks,
 } from '@plait-board/react-text';
+import { Node } from 'slate';
 
 const PATCHED_TEXT_MANAGES = new WeakSet<TextManage>();
 const BOARDS_WITH_LATEX_CACHE = new WeakSet<PlaitBoard>();
@@ -195,10 +197,14 @@ const bindLatexTextManageExit = (board: PlaitBoard, element: PlaitElement) => {
     const edit = textManage.edit.bind(textManage);
     textManage.edit = (callback, exitEdit) => {
       prepareLatexTextManageEdit(board, element);
-      return edit(() => {
-        callback?.();
-        schedulePostEditRefresh(board, element);
-      }, exitEdit);
+      const exit = edit(callback, (event) => {
+        return (
+          Boolean(exitEdit?.(event)) ||
+          shouldExitStandaloneLatexTextEdit(textManage, event)
+        );
+      });
+      scheduleActiveTextManageExitRefresh(board, element, textManage);
+      return exit;
     };
     PATCHED_TEXT_MANAGES.add(textManage);
     scheduleActiveTextManageExitRefresh(board, element, textManage);
@@ -214,8 +220,8 @@ const scheduleActiveTextManageExitRefresh = (
   editedElement: PlaitElement,
   textManage: TextManage
 ) => {
-  // A newly created text element can enter edit mode before this plugin binds
-  // textManage.edit, so watch the active edit once and refresh after it exits.
+  // TextManage invokes its callback before readonly rendering is restored, so
+  // wait for the edit session to fully close before measuring rendered LaTeX.
   if (
     !textManage.isEditing ||
     PENDING_TEXT_MANAGE_EXIT_REFRESHES.has(textManage)
@@ -226,14 +232,40 @@ const scheduleActiveTextManageExitRefresh = (
   PENDING_TEXT_MANAGE_EXIT_REFRESHES.add(textManage);
   const refreshWhenEditExits = () => {
     if (textManage.isEditing) {
-      setTimeout(refreshWhenEditExits, 50);
+      setTimeout(refreshWhenEditExits, 16);
       return;
     }
 
     PENDING_TEXT_MANAGE_EXIT_REFRESHES.delete(textManage);
     schedulePostEditRefresh(board, editedElement);
   };
-  setTimeout(refreshWhenEditExits, 50);
+  setTimeout(refreshWhenEditExits, 16);
+};
+
+const shouldExitStandaloneLatexTextEdit = (
+  textManage: TextManage,
+  event: Event
+) => {
+  if (
+    typeof KeyboardEvent === 'undefined' ||
+    !(event instanceof KeyboardEvent) ||
+    event.key !== 'Enter' ||
+    event.shiftKey ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey
+  ) {
+    return false;
+  }
+
+  const text = textManage.getText();
+  if (!hasLatexBlocksInTextElement(text)) {
+    return false;
+  }
+
+  return parseLatexBlocks(Node.string(text)).every(
+    (segment) => segment.type === 'latex' || segment.text.trim() === ''
+  );
 };
 
 const prepareLatexTextManageEdit = (

--- a/packages/drawnix/src/utils/image.ts
+++ b/packages/drawnix/src/utils/image.ts
@@ -1,5 +1,5 @@
 import { getSelectedElements, PlaitBoard, toSvgData } from '@plait/core';
-import { base64ToBlob, boardToImage, download } from './common';
+import { base64ToBlob, download } from './common';
 import { fileOpen } from '../data/filesystem';
 import { IMAGE_MIME_TYPES } from '../constants';
 import { insertImage } from '../data/image';
@@ -9,20 +9,47 @@ import { TRANSPARENT } from '../constants/color';
 type ClipboardImageFormat = 'svg' | 'png';
 type ExportElements = ReturnType<typeof getSelectedElements>;
 
+const EXPORT_PADDING = 20;
+const EXPORT_RATIO = 4;
+
 const CLIPBOARD_MIME_TYPES: Record<ClipboardImageFormat, string> = {
   svg: 'image/svg+xml',
   png: 'image/png',
 };
 
-const SVG_INLINE_STYLE_SELECTOR =
-  '.plait-text-container, .plait-latex-text-container, .plait-latex-block, .katex, .katex *';
+const EXPORT_INLINE_STYLE_SELECTOR =
+  '.extend,.emojis,.text,.plait-text-container,.plait-latex-text-container,.plait-latex-text-container *';
 
-const SVG_INLINE_STYLE_NAMES = [
+const EXPORT_INLINE_STYLE_NAMES = [
+  'background',
+  'background-color',
   'border',
+  'border-bottom',
+  'border-bottom-color',
+  'border-bottom-style',
+  'border-bottom-width',
+  'border-left',
+  'border-left-color',
+  'border-left-style',
+  'border-left-width',
+  'border-right',
+  'border-right-color',
+  'border-right-style',
+  'border-right-width',
+  'border-top',
+  'border-top-color',
+  'border-top-style',
+  'border-top-width',
   'bottom',
+  'box-sizing',
+  'clip',
+  'clip-path',
   'color',
+  'direction',
   'display',
   'font-family',
+  'font-feature-settings',
+  'font-kerning',
   'font-size',
   'font-style',
   'font-weight',
@@ -30,20 +57,38 @@ const SVG_INLINE_STYLE_NAMES = [
   'left',
   'line-height',
   'margin',
+  'margin-bottom',
+  'margin-left',
+  'margin-right',
+  'margin-top',
+  'max-height',
   'max-width',
+  'min-width',
   'min-height',
+  'opacity',
   'overflow',
   'padding',
+  'padding-bottom',
+  'padding-left',
+  'padding-right',
+  'padding-top',
   'position',
   'right',
   'text-align',
   'text-decoration',
   'top',
+  'transform',
+  'transform-origin',
+  'unicode-bidi',
   'vertical-align',
+  'visibility',
   'white-space',
   'width',
   'word-break',
+  'z-index',
 ];
+
+let katexFontFaceCssPromise: Promise<string> | null = null;
 
 const hasClipboardWriteSupport = () => {
   // Keep the ClipboardItem check local until the shared helper also covers it.
@@ -87,16 +132,21 @@ const writeBlobToClipboard = async (
   await navigator.clipboard.write([new ClipboardItem(item)]);
 };
 
-const getSvgBlob = async (board: PlaitBoard, elements?: ExportElements) => {
+const getSvgData = async (board: PlaitBoard, elements?: ExportElements) => {
   const backgroundColor = getBackgroundColor(board);
   const svgData = await toSvgData(board, {
     fillStyle: isWhite(backgroundColor) ? TRANSPARENT : backgroundColor,
-    padding: 20,
-    ratio: 4,
+    padding: EXPORT_PADDING,
+    ratio: EXPORT_RATIO,
     elements,
-    inlineStyleClassNames: SVG_INLINE_STYLE_SELECTOR,
-    styleNames: SVG_INLINE_STYLE_NAMES,
+    inlineStyleClassNames: EXPORT_INLINE_STYLE_SELECTOR,
+    styleNames: EXPORT_INLINE_STYLE_NAMES,
   });
+  return inlineKatexFontFaces(svgData);
+};
+
+const getSvgBlob = async (board: PlaitBoard, elements?: ExportElements) => {
+  const svgData = await getSvgData(board, elements);
   return new Blob([svgData], { type: CLIPBOARD_MIME_TYPES.svg });
 };
 
@@ -106,11 +156,174 @@ const getImageBlob = async (
   elements?: ExportElements
 ) => {
   const backgroundColor = getBackgroundColor(board) || 'white';
-  const imageDataUrl = await boardToImage(board, {
-    elements,
-    fillStyle: isTransparent ? 'transparent' : backgroundColor,
-  });
+  const svgData = await getSvgData(board, elements);
+  const imageDataUrl = await svgDataToImageDataUrl(
+    svgData,
+    isTransparent ? 'transparent' : backgroundColor,
+    EXPORT_RATIO
+  );
   return imageDataUrl ? base64ToBlob(imageDataUrl) : null;
+};
+
+const inlineKatexFontFaces = async (svgData: string) => {
+  if (!svgData.includes('KaTeX')) {
+    return svgData;
+  }
+
+  const css = await getKatexFontFaceCss();
+  if (!css) {
+    return svgData;
+  }
+
+  return svgData.replace(
+    /(<svg\b[^>]*>)/,
+    `$1<style type="text/css"><![CDATA[${css}]]></style>`
+  );
+};
+
+const getKatexFontFaceCss = () => {
+  if (!katexFontFaceCssPromise) {
+    katexFontFaceCssPromise = collectKatexFontFaceCss();
+  }
+  return katexFontFaceCssPromise;
+};
+
+const collectKatexFontFaceCss = async () => {
+  if (typeof document === 'undefined') {
+    return '';
+  }
+
+  const rules = getKatexFontFaceRules();
+  const css = await Promise.all(rules.map(buildEmbeddedFontFaceRule));
+  return css.filter(Boolean).join('\n');
+};
+
+const getKatexFontFaceRules = () => {
+  const rules: CSSFontFaceRule[] = [];
+  if (typeof CSSFontFaceRule === 'undefined') {
+    return rules;
+  }
+
+  Array.from(document.styleSheets).forEach((styleSheet) => {
+    let cssRules: CSSRuleList;
+    try {
+      cssRules = styleSheet.cssRules;
+    } catch {
+      return;
+    }
+
+    Array.from(cssRules).forEach((rule) => {
+      if (
+        rule instanceof CSSFontFaceRule &&
+        rule.style.getPropertyValue('font-family').includes('KaTeX')
+      ) {
+        rules.push(rule);
+      }
+    });
+  });
+  return rules;
+};
+
+const buildEmbeddedFontFaceRule = async (rule: CSSFontFaceRule) => {
+  const src = rule.style.getPropertyValue('src');
+  const fontUrl = getFirstFontUrl(src);
+  if (!fontUrl) {
+    return '';
+  }
+
+  const dataUrl = await fetchAsDataUrl(fontUrl);
+  if (!dataUrl) {
+    return '';
+  }
+
+  const fontFamily = rule.style.getPropertyValue('font-family');
+  const fontStyle = rule.style.getPropertyValue('font-style') || 'normal';
+  const fontWeight = rule.style.getPropertyValue('font-weight') || '400';
+
+  return [
+    '@font-face {',
+    `font-family: ${fontFamily};`,
+    `font-style: ${fontStyle};`,
+    `font-weight: ${fontWeight};`,
+    `src: url("${dataUrl}") format("woff2");`,
+    '}',
+  ].join('');
+};
+
+const getFirstFontUrl = (src: string) => {
+  const match = src.match(/url\(["']?([^"')]+\.woff2[^"')]*)["']?\)/);
+  if (!match) {
+    return null;
+  }
+  return new URL(match[1], document.baseURI).toString();
+};
+
+const fetchAsDataUrl = async (url: string) => {
+  try {
+    const response = await fetch(url);
+    const blob = await response.blob();
+    return await blobToDataUrl(blob);
+  } catch {
+    return null;
+  }
+};
+
+const blobToDataUrl = (blob: Blob) => {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+};
+
+const svgDataToImageDataUrl = (
+  svgData: string,
+  fillStyle: string,
+  ratio: number
+) => {
+  return new Promise<string | null>((resolve) => {
+    const { width, height } = getSvgSize(svgData);
+    if (!width || !height) {
+      resolve(null);
+      return;
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width * ratio;
+    canvas.height = height * ratio;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      resolve(null);
+      return;
+    }
+
+    if (fillStyle !== 'transparent') {
+      ctx.fillStyle = fillStyle;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
+
+    const image = new Image();
+    image.onload = () => {
+      ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+      resolve(canvas.toDataURL(CLIPBOARD_MIME_TYPES.png));
+    };
+    image.onerror = () => resolve(null);
+    image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(
+      svgData
+    )}`;
+  });
+};
+
+const getSvgSize = (svgData: string) => {
+  const documentElement = new DOMParser().parseFromString(
+    svgData,
+    'image/svg+xml'
+  ).documentElement;
+  return {
+    width: Number(documentElement.getAttribute('width')) || 0,
+    height: Number(documentElement.getAttribute('height')) || 0,
+  };
 };
 
 export const saveAsSvg = (board: PlaitBoard) => {

--- a/packages/drawnix/src/utils/image.ts
+++ b/packages/drawnix/src/utils/image.ts
@@ -14,6 +14,37 @@ const CLIPBOARD_MIME_TYPES: Record<ClipboardImageFormat, string> = {
   png: 'image/png',
 };
 
+const SVG_INLINE_STYLE_SELECTOR =
+  '.plait-text-container, .plait-latex-text-container, .plait-latex-block, .katex, .katex *';
+
+const SVG_INLINE_STYLE_NAMES = [
+  'border',
+  'bottom',
+  'color',
+  'display',
+  'font-family',
+  'font-size',
+  'font-style',
+  'font-weight',
+  'height',
+  'left',
+  'line-height',
+  'margin',
+  'max-width',
+  'min-height',
+  'overflow',
+  'padding',
+  'position',
+  'right',
+  'text-align',
+  'text-decoration',
+  'top',
+  'vertical-align',
+  'white-space',
+  'width',
+  'word-break',
+];
+
 const hasClipboardWriteSupport = () => {
   // Keep the ClipboardItem check local until the shared helper also covers it.
   return (
@@ -63,8 +94,8 @@ const getSvgBlob = async (board: PlaitBoard, elements?: ExportElements) => {
     padding: 20,
     ratio: 4,
     elements,
-    inlineStyleClassNames: '.plait-text-container',
-    styleNames: ['position'],
+    inlineStyleClassNames: SVG_INLINE_STYLE_SELECTOR,
+    styleNames: SVG_INLINE_STYLE_NAMES,
   });
   return new Blob([svgData], { type: CLIPBOARD_MIME_TYPES.svg });
 };

--- a/packages/react-text/package.json
+++ b/packages/react-text/package.json
@@ -11,7 +11,8 @@
     "slate-react": "^0.116.0",
     "@plait/text-plugins": "^0.93.1",
     "@plait/common": "^0.93.1",
-    "is-hotkey": "^0.2.0"
+    "is-hotkey": "^0.2.0",
+    "katex": "^0.16.21"
   },
   "exports": {
     ".": {

--- a/packages/react-text/src/index.ts
+++ b/packages/react-text/src/index.ts
@@ -1,2 +1,3 @@
 export * from './text';
 export * from './custom-types';
+export * from './latex';

--- a/packages/react-text/src/katex.d.ts
+++ b/packages/react-text/src/katex.d.ts
@@ -1,0 +1,22 @@
+declare module 'katex' {
+  export interface KatexOptions {
+    displayMode?: boolean;
+    output?: 'html' | 'mathml' | 'htmlAndMathml';
+    strict?: boolean | string | ((errorCode: string) => string | boolean);
+    throwOnError?: boolean;
+    trust?: boolean | ((context: unknown) => boolean);
+  }
+
+  export function renderToString(
+    expression: string,
+    options?: KatexOptions
+  ): string;
+
+  const katex: {
+    renderToString: typeof renderToString;
+  };
+
+  export default katex;
+}
+
+declare module 'katex/dist/katex.min.css';

--- a/packages/react-text/src/latex.spec.ts
+++ b/packages/react-text/src/latex.spec.ts
@@ -5,7 +5,12 @@ jest.mock('@plait/common', () => ({
   updateElementSizeCache: jest.fn(),
 }));
 
-import { hasLatexBlocks, parseLatexBlocks, renderLatexToString } from './latex';
+import {
+  hasLatexBlocks,
+  parseLatexBlocks,
+  renderLatexTextToHtml,
+  renderLatexToString,
+} from './latex';
 
 describe('latex blocks', () => {
   it('keeps plain text as a text segment', () => {
@@ -15,38 +20,16 @@ describe('latex blocks', () => {
     expect(hasLatexBlocks('plain text')).toBe(false);
   });
 
-  it('parses a single latex block', () => {
+  it('keeps explicit latex block markers as plain text', () => {
     expect(parseLatexBlocks('A \\latex x^2 \\endlatex B')).toEqual([
-      { type: 'text', text: 'A ', start: 0, end: 2 },
-      {
-        type: 'latex',
-        formula: 'x^2',
-        source: '\\latex x^2 \\endlatex',
-        start: 2,
-        end: 22,
-      },
-      { type: 'text', text: ' B', start: 22, end: 24 },
+      { type: 'text', text: 'A \\latex x^2 \\endlatex B', start: 0, end: 24 },
     ]);
   });
 
-  it('parses multiple and multiline latex blocks', () => {
+  it('keeps multiline explicit latex blocks as plain text', () => {
     const input = '\\latex x \\endlatex\nand\n\\latex y \\\\ z \\endlatex';
     expect(parseLatexBlocks(input)).toEqual([
-      {
-        type: 'latex',
-        formula: 'x',
-        source: '\\latex x \\endlatex',
-        start: 0,
-        end: 18,
-      },
-      { type: 'text', text: '\nand\n', start: 18, end: 23 },
-      {
-        type: 'latex',
-        formula: 'y \\\\ z',
-        source: '\\latex y \\\\ z \\endlatex',
-        start: 23,
-        end: 46,
-      },
+      { type: 'text', text: input, start: 0, end: 46 },
     ]);
   });
 
@@ -56,8 +39,60 @@ describe('latex blocks', () => {
     ]);
   });
 
+  it('parses common inline latex delimiters', () => {
+    expect(parseLatexBlocks('A \\(x^2\\) B')).toEqual([
+      { type: 'text', text: 'A ', start: 0, end: 2 },
+      {
+        type: 'latex',
+        displayMode: false,
+        formula: 'x^2',
+        source: '\\(x^2\\)',
+        start: 2,
+        end: 9,
+      },
+      { type: 'text', text: ' B', start: 9, end: 11 },
+    ]);
+  });
+
+  it('parses common display latex delimiters', () => {
+    expect(parseLatexBlocks('A \\[x^2\\] B')).toEqual([
+      { type: 'text', text: 'A ', start: 0, end: 2 },
+      {
+        type: 'latex',
+        displayMode: true,
+        formula: 'x^2',
+        source: '\\[x^2\\]',
+        start: 2,
+        end: 9,
+      },
+      { type: 'text', text: ' B', start: 9, end: 11 },
+    ]);
+  });
+
+  it('keeps dollar-delimited text unchanged for now', () => {
+    expect(parseLatexBlocks('A $x$ and $$y$$')).toEqual([
+      { type: 'text', text: 'A $x$ and $$y$$', start: 0, end: 15 },
+    ]);
+  });
+
   it('renders invalid latex without throwing', () => {
     expect(() => renderLatexToString('\\badcommand{')).not.toThrow();
     expect(renderLatexToString('\\badcommand{')).toContain('katex');
+  });
+
+  it('omits marker line breaks around rendered latex blocks', () => {
+    const html = renderLatexTextToHtml({
+      children: [
+        {
+          text: 'plain text\n\\[\nE = mc^2\n\\]\nafter text',
+        },
+      ],
+    } as any);
+    expect(html.startsWith('plain text<span class="plait-latex-block">')).toBe(
+      true
+    );
+    expect(html.endsWith('</span>after text')).toBe(true);
+    expect(html).not.toContain('plain text<br />');
+    expect(html).not.toContain('<br />after text');
   });
 });

--- a/packages/react-text/src/latex.spec.ts
+++ b/packages/react-text/src/latex.spec.ts
@@ -1,0 +1,63 @@
+jest.mock('@plait/common', () => ({
+  DEFAULT_FONT_FAMILY: 'Arial',
+  clearElementSizeCache: jest.fn(),
+  measureElement: jest.fn(() => ({ width: 1, height: 1 })),
+  updateElementSizeCache: jest.fn(),
+}));
+
+import { hasLatexBlocks, parseLatexBlocks, renderLatexToString } from './latex';
+
+describe('latex blocks', () => {
+  it('keeps plain text as a text segment', () => {
+    expect(parseLatexBlocks('plain text')).toEqual([
+      { type: 'text', text: 'plain text', start: 0, end: 10 },
+    ]);
+    expect(hasLatexBlocks('plain text')).toBe(false);
+  });
+
+  it('parses a single latex block', () => {
+    expect(parseLatexBlocks('A \\latex x^2 \\endlatex B')).toEqual([
+      { type: 'text', text: 'A ', start: 0, end: 2 },
+      {
+        type: 'latex',
+        formula: 'x^2',
+        source: '\\latex x^2 \\endlatex',
+        start: 2,
+        end: 22,
+      },
+      { type: 'text', text: ' B', start: 22, end: 24 },
+    ]);
+  });
+
+  it('parses multiple and multiline latex blocks', () => {
+    const input = '\\latex x \\endlatex\nand\n\\latex y \\\\ z \\endlatex';
+    expect(parseLatexBlocks(input)).toEqual([
+      {
+        type: 'latex',
+        formula: 'x',
+        source: '\\latex x \\endlatex',
+        start: 0,
+        end: 18,
+      },
+      { type: 'text', text: '\nand\n', start: 18, end: 23 },
+      {
+        type: 'latex',
+        formula: 'y \\\\ z',
+        source: '\\latex y \\\\ z \\endlatex',
+        start: 23,
+        end: 46,
+      },
+    ]);
+  });
+
+  it('keeps an unclosed latex block as text', () => {
+    expect(parseLatexBlocks('A \\latex x^2')).toEqual([
+      { type: 'text', text: 'A \\latex x^2', start: 0, end: 12 },
+    ]);
+  });
+
+  it('renders invalid latex without throwing', () => {
+    expect(() => renderLatexToString('\\badcommand{')).not.toThrow();
+    expect(renderLatexToString('\\badcommand{')).toContain('katex');
+  });
+});

--- a/packages/react-text/src/latex.spec.ts
+++ b/packages/react-text/src/latex.spec.ts
@@ -4,6 +4,7 @@ import {
   renderLatexTextToHtml,
   renderLatexToString,
 } from './latex';
+import type { ParagraphElement } from '@plait/common';
 
 jest.mock('@plait/common', () => ({
   DEFAULT_FONT_FAMILY: 'Arial',
@@ -94,5 +95,22 @@ describe('latex blocks', () => {
     expect(html.endsWith('</span>after text')).toBe(true);
     expect(html).not.toContain('plain text<br />');
     expect(html).not.toContain('<br />after text');
+  });
+
+  it('preserves text marks when rendering latex html', () => {
+    const element: ParagraphElement = {
+      children: [
+        {
+          text: '\\[\\pi\\]',
+          'font-size': 24,
+          italic: true,
+        },
+      ],
+    };
+    const html = renderLatexTextToHtml(element);
+
+    expect(html).toContain('font-size: 24px');
+    expect(html).toContain('line-height: 1.5');
+    expect(html).toContain('font-style: italic');
   });
 });

--- a/packages/react-text/src/latex.spec.ts
+++ b/packages/react-text/src/latex.spec.ts
@@ -1,16 +1,16 @@
-jest.mock('@plait/common', () => ({
-  DEFAULT_FONT_FAMILY: 'Arial',
-  clearElementSizeCache: jest.fn(),
-  measureElement: jest.fn(() => ({ width: 1, height: 1 })),
-  updateElementSizeCache: jest.fn(),
-}));
-
 import {
   hasLatexBlocks,
   parseLatexBlocks,
   renderLatexTextToHtml,
   renderLatexToString,
 } from './latex';
+
+jest.mock('@plait/common', () => ({
+  DEFAULT_FONT_FAMILY: 'Arial',
+  clearElementSizeCache: jest.fn(),
+  measureElement: jest.fn(() => ({ width: 1, height: 1 })),
+  updateElementSizeCache: jest.fn(),
+}));
 
 describe('latex blocks', () => {
   it('keeps plain text as a text segment', () => {

--- a/packages/react-text/src/latex.ts
+++ b/packages/react-text/src/latex.ts
@@ -12,9 +12,6 @@ import type { PlaitBoard } from '@plait/core';
 import katex from 'katex';
 import { Element as SlateElement, Node, Text } from 'slate';
 
-export const LATEX_BLOCK_START = '\\latex';
-export const LATEX_BLOCK_END = '\\endlatex';
-
 export type LatexTextSegment =
   | {
       type: 'text';
@@ -24,6 +21,7 @@ export type LatexTextSegment =
     }
   | {
       type: 'latex';
+      displayMode: boolean;
       formula: string;
       source: string;
       start: number;
@@ -37,6 +35,11 @@ export type LatexMeasureOptions = {
   includeSourceSize?: boolean;
 };
 
+export type LatexTextRenderRange = {
+  start: number;
+  end: number;
+};
+
 const DEFAULT_FONT_SIZE = 14;
 const DEFAULT_MAX_WIDTH = 10000;
 
@@ -45,8 +48,8 @@ export const parseLatexBlocks = (input: string): LatexTextSegment[] => {
   let cursor = 0;
 
   while (cursor < input.length) {
-    const start = input.indexOf(LATEX_BLOCK_START, cursor);
-    if (start === -1) {
+    const nextSyntax = findNextLatexSyntax(input, cursor);
+    if (!nextSyntax) {
       segments.push({
         type: 'text',
         text: input.slice(cursor),
@@ -56,8 +59,9 @@ export const parseLatexBlocks = (input: string): LatexTextSegment[] => {
       break;
     }
 
-    const contentStart = start + LATEX_BLOCK_START.length;
-    const end = input.indexOf(LATEX_BLOCK_END, contentStart);
+    const { syntax, start } = nextSyntax;
+    const contentStart = start + syntax.startToken.length;
+    const end = findLatexSyntaxEnd(input, syntax, contentStart);
     if (end === -1) {
       segments.push({
         type: 'text',
@@ -68,6 +72,10 @@ export const parseLatexBlocks = (input: string): LatexTextSegment[] => {
       break;
     }
 
+    const sourceEnd = end + syntax.endToken.length;
+    const source = input.slice(start, sourceEnd);
+    const formula = input.slice(contentStart, end).trim();
+
     if (start > cursor) {
       segments.push({
         type: 'text',
@@ -77,11 +85,11 @@ export const parseLatexBlocks = (input: string): LatexTextSegment[] => {
       });
     }
 
-    const sourceEnd = end + LATEX_BLOCK_END.length;
     segments.push({
       type: 'latex',
-      formula: input.slice(contentStart, end).trim(),
-      source: input.slice(start, sourceEnd),
+      displayMode: syntax.displayMode,
+      formula,
+      source,
       start,
       end: sourceEnd,
     });
@@ -104,9 +112,16 @@ export const hasLatexBlocksInTextElement = (element: Node) => {
 };
 
 export const renderLatexToString = (formula: string) => {
+  return renderLatexFormulaToString(formula, true);
+};
+
+export const renderLatexFormulaToString = (
+  formula: string,
+  displayMode: boolean
+) => {
   try {
     return katex.renderToString(formula, {
-      displayMode: true,
+      displayMode,
       output: 'html',
       strict: false,
       throwOnError: false,
@@ -118,16 +133,52 @@ export const renderLatexToString = (formula: string) => {
 };
 
 export const renderLatexTextToHtml = (element: Node) => {
-  return parseLatexBlocks(Node.string(element))
-    .map((segment) => {
+  const segments = parseLatexBlocks(Node.string(element));
+  return segments
+    .map((segment, index) => {
       if (segment.type === 'latex') {
-        return `<span class="plait-latex-block">${renderLatexToString(
-          segment.formula
+        const className = segment.displayMode
+          ? 'plait-latex-block'
+          : 'plait-latex-inline';
+        return `<span class="${className}">${renderLatexFormulaToString(
+          segment.formula,
+          segment.displayMode
         )}</span>`;
       }
-      return escapeHtml(segment.text).replace(/\n/g, '<br />');
+      const range = getLatexTextRenderRange(segments, index);
+      return escapeHtml(
+        segment.text.slice(
+          range.start - segment.start,
+          range.end - segment.start
+        )
+      ).replace(/\n/g, '<br />');
     })
     .join('');
+};
+
+export const getLatexTextRenderRange = (
+  segments: LatexTextSegment[],
+  index: number
+): LatexTextRenderRange => {
+  const segment = segments[index];
+  if (!segment || segment.type !== 'text') {
+    return {
+      start: segment?.start || 0,
+      end: segment?.end || 0,
+    };
+  }
+
+  let start = segment.start;
+  let end = segment.end;
+
+  if (isDisplayLatexSegment(segments[index - 1])) {
+    start = skipLeadingNewline(segment.text, start);
+  }
+  if (isDisplayLatexSegment(segments[index + 1])) {
+    end = trimTrailingNewline(segment.text, segment.start, end);
+  }
+
+  return { start, end };
 };
 
 export const isParagraphTextElement = (
@@ -253,6 +304,99 @@ const escapeHtml = (input: string) => {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+};
+
+type LatexSyntax = {
+  displayMode: boolean;
+  endToken: string;
+  kind: 'display-bracket' | 'inline-paren';
+  startToken: string;
+};
+
+const LATEX_SYNTAXES: LatexSyntax[] = [
+  {
+    displayMode: true,
+    endToken: '\\]',
+    kind: 'display-bracket',
+    startToken: '\\[',
+  },
+  {
+    displayMode: false,
+    endToken: '\\)',
+    kind: 'inline-paren',
+    startToken: '\\(',
+  },
+];
+
+const findNextLatexSyntax = (input: string, cursor: number) => {
+  return LATEX_SYNTAXES.map((syntax) => ({
+    start: findLatexSyntaxStart(input, syntax, cursor),
+    syntax,
+  }))
+    .filter((value) => value.start !== -1)
+    .sort((a, b) => a.start - b.start)[0];
+};
+
+const findLatexSyntaxStart = (
+  input: string,
+  syntax: LatexSyntax,
+  cursor: number
+) => {
+  return findUnescapedToken(input, syntax.startToken, cursor);
+};
+
+const findLatexSyntaxEnd = (
+  input: string,
+  syntax: LatexSyntax,
+  cursor: number
+) => {
+  return findUnescapedToken(input, syntax.endToken, cursor);
+};
+
+const findUnescapedToken = (input: string, token: string, cursor: number) => {
+  let index = input.indexOf(token, cursor);
+  while (index !== -1 && isEscaped(input, index)) {
+    index = input.indexOf(token, index + token.length);
+  }
+  return index;
+};
+
+const isEscaped = (input: string, index: number) => {
+  let slashCount = 0;
+  for (let i = index - 1; i >= 0 && input[i] === '\\'; i--) {
+    slashCount++;
+  }
+  return slashCount % 2 === 1;
+};
+
+const isDisplayLatexSegment = (
+  segment: LatexTextSegment | undefined
+): segment is Extract<LatexTextSegment, { type: 'latex' }> => {
+  return segment?.type === 'latex' && segment.displayMode;
+};
+
+const skipLeadingNewline = (text: string, start: number) => {
+  if (text.startsWith('\r\n')) {
+    return start + 2;
+  }
+  if (text.startsWith('\n') || text.startsWith('\r')) {
+    return start + 1;
+  }
+  return start;
+};
+
+const trimTrailingNewline = (
+  text: string,
+  segmentStart: number,
+  end: number
+) => {
+  if (text.endsWith('\r\n')) {
+    return Math.max(segmentStart, end - 2);
+  }
+  if (text.endsWith('\n') || text.endsWith('\r')) {
+    return Math.max(segmentStart, end - 1);
+  }
+  return end;
 };
 
 const isObject = (value: unknown): value is Record<string, unknown> => {

--- a/packages/react-text/src/latex.ts
+++ b/packages/react-text/src/latex.ts
@@ -1,5 +1,3 @@
-/// <reference path="./katex.d.ts" />
-
 import {
   DEFAULT_FONT_FAMILY,
   clearElementSizeCache,

--- a/packages/react-text/src/latex.ts
+++ b/packages/react-text/src/latex.ts
@@ -1,0 +1,271 @@
+/// <reference path="./katex.d.ts" />
+
+import {
+  DEFAULT_FONT_FAMILY,
+  clearElementSizeCache,
+  measureElement,
+  updateElementSizeCache,
+  type ElementSize,
+  type ParagraphElement,
+} from '@plait/common';
+import type { PlaitBoard } from '@plait/core';
+import katex from 'katex';
+import { Element as SlateElement, Node, Text } from 'slate';
+
+export const LATEX_BLOCK_START = '\\latex';
+export const LATEX_BLOCK_END = '\\endlatex';
+
+export type LatexTextSegment =
+  | {
+      type: 'text';
+      text: string;
+      start: number;
+      end: number;
+    }
+  | {
+      type: 'latex';
+      formula: string;
+      source: string;
+      start: number;
+      end: number;
+    };
+
+export type LatexMeasureOptions = {
+  fontFamily?: string;
+  fontSize?: number;
+  maxWidth?: number;
+  includeSourceSize?: boolean;
+};
+
+const DEFAULT_FONT_SIZE = 14;
+const DEFAULT_MAX_WIDTH = 10000;
+
+export const parseLatexBlocks = (input: string): LatexTextSegment[] => {
+  const segments: LatexTextSegment[] = [];
+  let cursor = 0;
+
+  while (cursor < input.length) {
+    const start = input.indexOf(LATEX_BLOCK_START, cursor);
+    if (start === -1) {
+      segments.push({
+        type: 'text',
+        text: input.slice(cursor),
+        start: cursor,
+        end: input.length,
+      });
+      break;
+    }
+
+    const contentStart = start + LATEX_BLOCK_START.length;
+    const end = input.indexOf(LATEX_BLOCK_END, contentStart);
+    if (end === -1) {
+      segments.push({
+        type: 'text',
+        text: input.slice(cursor),
+        start: cursor,
+        end: input.length,
+      });
+      break;
+    }
+
+    if (start > cursor) {
+      segments.push({
+        type: 'text',
+        text: input.slice(cursor, start),
+        start: cursor,
+        end: start,
+      });
+    }
+
+    const sourceEnd = end + LATEX_BLOCK_END.length;
+    segments.push({
+      type: 'latex',
+      formula: input.slice(contentStart, end).trim(),
+      source: input.slice(start, sourceEnd),
+      start,
+      end: sourceEnd,
+    });
+    cursor = sourceEnd;
+  }
+
+  if (!segments.length) {
+    return [{ type: 'text', text: '', start: 0, end: 0 }];
+  }
+
+  return segments;
+};
+
+export const hasLatexBlocks = (input: string) => {
+  return parseLatexBlocks(input).some((segment) => segment.type === 'latex');
+};
+
+export const hasLatexBlocksInTextElement = (element: Node) => {
+  return hasLatexBlocks(Node.string(element));
+};
+
+export const renderLatexToString = (formula: string) => {
+  try {
+    return katex.renderToString(formula, {
+      displayMode: true,
+      output: 'html',
+      strict: false,
+      throwOnError: false,
+      trust: false,
+    });
+  } catch {
+    return escapeHtml(formula);
+  }
+};
+
+export const renderLatexTextToHtml = (element: Node) => {
+  return parseLatexBlocks(Node.string(element))
+    .map((segment) => {
+      if (segment.type === 'latex') {
+        return `<span class="plait-latex-block">${renderLatexToString(
+          segment.formula
+        )}</span>`;
+      }
+      return escapeHtml(segment.text).replace(/\n/g, '<br />');
+    })
+    .join('');
+};
+
+export const isParagraphTextElement = (
+  value: unknown
+): value is ParagraphElement => {
+  if (!isObject(value) || !Array.isArray((value as any).children)) {
+    return false;
+  }
+  return (value as any).children.some(isSlateTextChild);
+};
+
+export const findTextElements = (value: unknown): ParagraphElement[] => {
+  const elements: ParagraphElement[] = [];
+  const visited = new WeakSet<object>();
+
+  const visit = (node: unknown) => {
+    if (!isObject(node) || visited.has(node)) {
+      return;
+    }
+    visited.add(node);
+
+    if (isParagraphTextElement(node)) {
+      elements.push(node);
+      return;
+    }
+
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+
+    Object.values(node).forEach(visit);
+  };
+
+  visit(value);
+  return elements;
+};
+
+export const findLatexTextElements = (value: unknown): ParagraphElement[] => {
+  return findTextElements(value).filter(hasLatexBlocksInTextElement);
+};
+
+export const measureLatexTextElement = (
+  element: Node,
+  options: LatexMeasureOptions = {}
+): ElementSize | null => {
+  if (
+    typeof document === 'undefined' ||
+    !hasLatexBlocksInTextElement(element)
+  ) {
+    return null;
+  }
+
+  const fontSize = options.fontSize || DEFAULT_FONT_SIZE;
+  const maxWidth = options.maxWidth || DEFAULT_MAX_WIDTH;
+  const container = document.createElement('div');
+  container.className = 'plait-text-container plait-latex-text-container';
+  container.style.position = 'absolute';
+  container.style.left = '-10000px';
+  container.style.top = '-10000px';
+  container.style.visibility = 'hidden';
+  container.style.pointerEvents = 'none';
+  container.style.whiteSpace = 'pre-wrap';
+  container.style.wordBreak = 'break-word';
+  container.style.maxWidth = `${maxWidth}px`;
+  container.style.fontFamily = options.fontFamily || DEFAULT_FONT_FAMILY;
+  container.style.fontSize = `${fontSize}px`;
+  container.style.lineHeight = fontSize === DEFAULT_FONT_SIZE ? '20px' : '1.5';
+  container.innerHTML = renderLatexTextToHtml(element);
+
+  document.body.appendChild(container);
+  const rect = container.getBoundingClientRect();
+  const size = {
+    width: Math.ceil(
+      Math.min(Math.max(rect.width, container.scrollWidth), maxWidth)
+    ),
+    height: Math.ceil(Math.max(rect.height, container.scrollHeight)),
+  };
+  container.remove();
+  return size;
+};
+
+export const cacheLatexTextElementSize = (
+  board: PlaitBoard | null,
+  element: ParagraphElement,
+  options: LatexMeasureOptions = {}
+) => {
+  clearElementSizeCache(board, element);
+  if (!hasLatexBlocksInTextElement(element)) {
+    return false;
+  }
+
+  const latexSize = measureLatexTextElement(element, options);
+  if (!latexSize) {
+    return false;
+  }
+
+  let size = latexSize;
+  if (options.includeSourceSize) {
+    const sourceSize = measureElement(
+      board,
+      element,
+      {
+        fontFamily: options.fontFamily || DEFAULT_FONT_FAMILY,
+        fontSize: options.fontSize || DEFAULT_FONT_SIZE,
+      },
+      options.maxWidth || DEFAULT_MAX_WIDTH
+    );
+    size = {
+      width: Math.max(latexSize.width, sourceSize.width),
+      height: Math.max(latexSize.height, sourceSize.height),
+    };
+  }
+
+  updateElementSizeCache(board, element, size);
+  return true;
+};
+
+const escapeHtml = (input: string) => {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+};
+
+const isObject = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null;
+};
+
+const isSlateTextChild = (value: unknown) => {
+  if (Text.isText(value)) {
+    return true;
+  }
+  return (
+    SlateElement.isElement(value) &&
+    (value as any).type === 'link' &&
+    Array.isArray((value as any).children)
+  );
+};

--- a/packages/react-text/src/latex.ts
+++ b/packages/react-text/src/latex.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="./katex.d.ts" />
+
 import {
   DEFAULT_FONT_FAMILY,
   clearElementSizeCache,

--- a/packages/react-text/src/latex.ts
+++ b/packages/react-text/src/latex.ts
@@ -7,6 +7,7 @@ import {
   measureElement,
   updateElementSizeCache,
   type ElementSize,
+  type CustomText,
   type ParagraphElement,
 } from '@plait/common';
 import type { PlaitBoard } from '@plait/core';
@@ -39,6 +40,13 @@ export type LatexMeasureOptions = {
 export type LatexTextRenderRange = {
   start: number;
   end: number;
+};
+
+type FlattenedTextLeaf = {
+  end: number;
+  marks: Omit<CustomText, 'text'>;
+  start: number;
+  text: string;
 };
 
 const DEFAULT_FONT_SIZE = 14;
@@ -135,24 +143,23 @@ export const renderLatexFormulaToString = (
 
 export const renderLatexTextToHtml = (element: Node) => {
   const segments = parseLatexBlocks(Node.string(element));
+  const leaves = flattenTextLeaves(element);
   return segments
     .map((segment, index) => {
       if (segment.type === 'latex') {
         const className = segment.displayMode
           ? 'plait-latex-block'
           : 'plait-latex-inline';
-        return `<span class="${className}">${renderLatexFormulaToString(
+        const style = getLeafStyleAttribute(
+          getMarksAtOffset(leaves, segment.start)
+        );
+        return `<span class="${className}"${style}>${renderLatexFormulaToString(
           segment.formula,
           segment.displayMode
         )}</span>`;
       }
       const range = getLatexTextRenderRange(segments, index);
-      return escapeHtml(
-        segment.text.slice(
-          range.start - segment.start,
-          range.end - segment.start
-        )
-      ).replace(/\n/g, '<br />');
+      return renderTextRangeToHtml(leaves, range.start, range.end);
     })
     .join('');
 };
@@ -305,6 +312,95 @@ const escapeHtml = (input: string) => {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+};
+
+const flattenTextLeaves = (element: Node) => {
+  const leaves: FlattenedTextLeaf[] = [];
+  let offset = 0;
+
+  for (const [node] of Node.texts(element)) {
+    const text = node.text;
+    const start = offset;
+    offset += text.length;
+    leaves.push({
+      end: offset,
+      marks: node,
+      start,
+      text,
+    });
+  }
+
+  return leaves;
+};
+
+const renderTextRangeToHtml = (
+  leaves: FlattenedTextLeaf[],
+  start: number,
+  end: number
+) => {
+  return leaves
+    .filter((leaf) => leaf.end > start && leaf.start < end)
+    .map((leaf) => {
+      const sliceStart = Math.max(start, leaf.start) - leaf.start;
+      const sliceEnd = Math.min(end, leaf.end) - leaf.start;
+      const content = renderTextWithBreaksToHtml(
+        leaf.text.slice(sliceStart, sliceEnd)
+      );
+      const style = getLeafStyleAttribute(leaf.marks);
+
+      return style ? `<span${style}>${content}</span>` : content;
+    })
+    .join('');
+};
+
+const renderTextWithBreaksToHtml = (text: string) => {
+  return escapeHtml(text).replace(/\n/g, '<br />');
+};
+
+const getMarksAtOffset = (
+  leaves: FlattenedTextLeaf[],
+  offset: number
+): Omit<CustomText, 'text'> | undefined => {
+  return (
+    leaves.find((leaf) => leaf.start <= offset && offset < leaf.end)?.marks ||
+    leaves.find((leaf) => leaf.end === offset)?.marks
+  );
+};
+
+const getLeafStyleAttribute = (leaf?: Omit<CustomText, 'text'>) => {
+  if (!leaf) {
+    return '';
+  }
+
+  const declarations: string[] = [];
+  const fontSizeValue = leaf['font-size'];
+  if (fontSizeValue) {
+    declarations.push(`font-size: ${fontSizeValue}px`);
+    declarations.push('line-height: 1.5');
+  }
+  if (leaf.color) {
+    declarations.push(`color: ${leaf.color}`);
+  }
+  if (leaf.italic) {
+    declarations.push('font-style: italic');
+  }
+  if (leaf.bold) {
+    declarations.push('font-weight: bold');
+  }
+
+  const textDecorations = [
+    leaf.underlined ? 'underline' : '',
+    leaf.strike ? 'line-through' : '',
+  ].filter(Boolean);
+  if (textDecorations.length) {
+    declarations.push(`text-decoration: ${textDecorations.join(' ')}`);
+  }
+
+  if (!declarations.length) {
+    return '';
+  }
+
+  return ` style="${escapeHtml(`${declarations.join('; ')};`)}"`;
 };
 
 type LatexSyntax = {

--- a/packages/react-text/src/styles/index.scss
+++ b/packages/react-text/src/styles/index.scss
@@ -53,3 +53,18 @@
         }
     }
 }
+
+.plait-latex-text-container {
+    white-space: pre-wrap;
+    word-break: break-word;
+
+    .plait-latex-block {
+        display: block;
+        overflow: visible;
+
+        .katex-display {
+            margin: 0.2em 0;
+            overflow: visible;
+        }
+    }
+}

--- a/packages/react-text/src/styles/index.scss
+++ b/packages/react-text/src/styles/index.scss
@@ -55,16 +55,28 @@
 }
 
 .plait-latex-text-container {
+    display: block;
     white-space: pre-wrap;
     word-break: break-word;
+    text-align: inherit;
+    user-select: none;
+    -webkit-user-select: none;
+
+    .plait-latex-inline {
+        display: inline-block;
+        vertical-align: baseline;
+        white-space: normal;
+    }
 
     .plait-latex-block {
         display: block;
         overflow: visible;
+        text-align: inherit;
 
         .katex-display {
-            margin: 0.2em 0;
+            margin: 0;
             overflow: visible;
+            text-align: inherit;
         }
     }
 }

--- a/packages/react-text/src/text.spec.tsx
+++ b/packages/react-text/src/text.spec.tsx
@@ -28,7 +28,7 @@ describe('Text', () => {
 
   it('renders latex blocks in readonly text', () => {
     const ele: Element = {
-      children: [{ text: '\\latex x^2 \\endlatex' }],
+      children: [{ text: '\\[x^2\\]' }],
       type: 'paragraph',
     };
     const { container } = render(<Text text={ele} board={{} as any} />);
@@ -37,13 +37,64 @@ describe('Text', () => {
 
   it('keeps latex source visible while editing', () => {
     const ele: Element = {
-      children: [{ text: '\\latex x^2 \\endlatex' }],
+      children: [{ text: '\\[x^2\\]' }],
       type: 'paragraph',
     };
     const { container } = render(
       <Text text={ele} board={{} as any} readonly={false} />
     );
     expect(container.querySelector('.katex')).toBeFalsy();
+    expect(container.textContent).toContain('\\[x^2\\]');
+  });
+
+  it('does not render explicit latex block markers', () => {
+    const ele: Element = {
+      children: [{ text: '\\latex x^2 \\endlatex' }],
+      type: 'paragraph',
+    };
+    const { container } = render(<Text text={ele} board={{} as any} />);
+    expect(container.querySelector('.katex')).toBeFalsy();
     expect(container.textContent).toContain('\\latex x^2 \\endlatex');
+  });
+
+  it('copies latex source instead of rendered katex text', () => {
+    const ele: Element = {
+      children: [
+        {
+          text: 'Before\n\\[\n\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}\n\\]\nAfter',
+        },
+      ],
+      type: 'paragraph',
+    };
+    const { container } = render(<Text text={ele} board={{} as any} />);
+    const latexContainer = container.querySelector(
+      '.plait-latex-text-container'
+    );
+    const setData = jest.fn();
+    const selection = {
+      anchorNode: latexContainer?.firstChild,
+      focusNode: latexContainer?.firstChild,
+      isCollapsed: false,
+      toString: () => 'Before rendered formula After',
+    };
+    jest.spyOn(window, 'getSelection').mockReturnValue(selection as any);
+
+    const event = new Event('copy', {
+      bubbles: true,
+      cancelable: true,
+    }) as ClipboardEvent;
+    Object.defineProperty(event, 'clipboardData', {
+      value: { setData },
+    });
+    document.dispatchEvent(event);
+
+    expect(setData).toHaveBeenCalledWith(
+      'text/plain',
+      (ele.children[0] as any).text
+    );
+    expect(setData).toHaveBeenCalledWith(
+      'text/html',
+      expect.stringContaining('\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}')
+    );
   });
 });

--- a/packages/react-text/src/text.spec.tsx
+++ b/packages/react-text/src/text.spec.tsx
@@ -1,3 +1,19 @@
+jest.mock('@plait/common', () => ({
+  DEFAULT_FONT_FAMILY: 'Arial',
+  clearElementSizeCache: jest.fn(),
+  measureElement: jest.fn(() => ({ width: 1, height: 1 })),
+  updateElementSizeCache: jest.fn(),
+}));
+
+jest.mock('@plait/text-plugins', () => ({
+  isUrl: jest.fn(() => false),
+  LinkEditor: {
+    isLinkActive: jest.fn(() => false),
+    unwrapLink: jest.fn(),
+    wrapLink: jest.fn(),
+  },
+}));
+
 import { render } from '@testing-library/react';
 
 import { Text } from './text';
@@ -8,5 +24,26 @@ describe('Text', () => {
     // const ele: Element = { children: [{ text: '' }], type: 'paragraph' };
     // const { baseElement } = render(<Text text={ele} board={{} as any} />);
     // expect(baseElement).toBeTruthy();
+  });
+
+  it('renders latex blocks in readonly text', () => {
+    const ele: Element = {
+      children: [{ text: '\\latex x^2 \\endlatex' }],
+      type: 'paragraph',
+    };
+    const { container } = render(<Text text={ele} board={{} as any} />);
+    expect(container.querySelector('.katex')).toBeTruthy();
+  });
+
+  it('keeps latex source visible while editing', () => {
+    const ele: Element = {
+      children: [{ text: '\\latex x^2 \\endlatex' }],
+      type: 'paragraph',
+    };
+    const { container } = render(
+      <Text text={ele} board={{} as any} readonly={false} />
+    );
+    expect(container.querySelector('.katex')).toBeFalsy();
+    expect(container.textContent).toContain('\\latex x^2 \\endlatex');
   });
 });

--- a/packages/react-text/src/text.spec.tsx
+++ b/packages/react-text/src/text.spec.tsx
@@ -1,3 +1,8 @@
+import { render } from '@testing-library/react';
+import { Element } from 'slate';
+
+import { Text } from './text';
+
 jest.mock('@plait/common', () => ({
   DEFAULT_FONT_FAMILY: 'Arial',
   clearElementSizeCache: jest.fn(),
@@ -13,11 +18,6 @@ jest.mock('@plait/text-plugins', () => ({
     wrapLink: jest.fn(),
   },
 }));
-
-import { render } from '@testing-library/react';
-
-import { Text } from './text';
-import { Element } from 'slate';
 
 describe('Text', () => {
   it('should render successfully', () => {

--- a/packages/react-text/src/text.spec.tsx
+++ b/packages/react-text/src/text.spec.tsx
@@ -35,6 +35,42 @@ describe('Text', () => {
     expect(container.querySelector('.katex')).toBeTruthy();
   });
 
+  it('uses marks from the leaf containing a latex segment', () => {
+    const ele: Element = {
+      children: [
+        { text: 'before ', 'font-size': 12 },
+        { text: '\\(x^2\\)', 'font-size': 28 },
+      ],
+      type: 'paragraph',
+    } as any;
+    const { container } = render(<Text text={ele} board={{} as any} />);
+    const latex = container.querySelector(
+      '.plait-latex-inline'
+    ) as HTMLElement;
+
+    expect(latex.style.fontSize).toBe('28px');
+  });
+
+  it('preserves link markup while rendering latex text', () => {
+    const ele: Element = {
+      children: [
+        {
+          children: [{ text: 'link' }],
+          type: 'link',
+          url: 'https://example.com',
+        },
+        { text: ' \\(x\\)' },
+      ],
+      type: 'paragraph',
+    } as any;
+    const { container } = render(<Text text={ele} board={{} as any} />);
+    const link = container.querySelector('a') as HTMLElement;
+
+    expect(link.className).toBe('plait-board-link');
+    expect(link.getAttribute('data-url')).toBe('https://example.com');
+    expect(link.getAttribute('href')).toBe('https://example.com');
+  });
+
   it('keeps latex source visible while editing', () => {
     const ele: Element = {
       children: [{ text: '\\[x^2\\]' }],

--- a/packages/react-text/src/text.tsx
+++ b/packages/react-text/src/text.tsx
@@ -22,7 +22,13 @@ import {
   type ParagraphElement,
   type TextProps,
 } from '@plait/common';
-import React, { useMemo, useCallback, useEffect, CSSProperties } from 'react';
+import React, {
+  useMemo,
+  useCallback,
+  useEffect,
+  CSSProperties,
+  useRef,
+} from 'react';
 import { withHistory } from 'slate-history';
 import { isUrl, LinkEditor } from '@plait/text-plugins';
 import { withText } from './plugins/with-text';
@@ -31,9 +37,10 @@ import { CustomEditor, RenderElementPropsFor } from './custom-types';
 import './styles/index.scss';
 import { LinkComponent, withInlineLink } from './plugins/with-link';
 import {
+  getLatexTextRenderRange,
   hasLatexBlocksInTextElement,
   parseLatexBlocks,
-  renderLatexToString,
+  renderLatexFormulaToString,
 } from './latex';
 import 'katex/dist/katex.min.css';
 
@@ -45,6 +52,8 @@ export const Text: React.FC<TextComponentProps> = (
   const { text, readonly, onChange, onComposition, afterInit } = props;
 
   const isReadonly = readonly === undefined ? true : readonly;
+  const editableRef = useRef<HTMLDivElement | null>(null);
+  const shouldRenderLatex = isReadonly && hasLatexBlocksInTextElement(text);
 
   const renderLeaf = useCallback(
     (props: RenderLeafProps) => <Leaf {...props} />,
@@ -68,6 +77,29 @@ export const Text: React.FC<TextComponentProps> = (
     editor.children = [text];
     editor.onChange();
   }, [text, editor]);
+
+  useEffect(() => {
+    if (!shouldRenderLatex) {
+      return;
+    }
+
+    const handleCopy = (event: ClipboardEvent) => {
+      if (!editableRef.current || !isDomSelectionInside(editableRef.current)) {
+        return;
+      }
+
+      writePlainTextClipboard(event.clipboardData, Node.string(text));
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    document.addEventListener('copy', handleCopy, true);
+    document.addEventListener('cut', handleCopy, true);
+    return () => {
+      document.removeEventListener('copy', handleCopy, true);
+      document.removeEventListener('cut', handleCopy, true);
+    };
+  }, [shouldRenderLatex, text]);
 
   const onKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
     const { selection } = editor;
@@ -106,6 +138,7 @@ export const Text: React.FC<TextComponentProps> = (
       }}
     >
       <Editable
+        ref={editableRef}
         className="slate-editable-container plait-text-container"
         renderElement={(props) => (
           <Element {...props} renderLatex={isReadonly} />
@@ -232,30 +265,36 @@ const LatexTextContent = ({ element }: { element: ParagraphElement }) => {
           const marks = getMarksAtOffset(leaves, segment.start);
           return (
             <LatexBlock
+              displayMode={segment.displayMode}
               formula={segment.formula}
               key={`${segment.start}-${index}`}
               marks={marks}
             />
           );
         }
-        return renderTextRange(leaves, segment.start, segment.end, index);
+        const range = getLatexTextRenderRange(segments, index);
+        return renderTextRange(leaves, range.start, range.end, index);
       })}
     </span>
   );
 };
 
 const LatexBlock = ({
+  displayMode,
   formula,
   marks,
 }: {
+  displayMode: boolean;
   formula: string;
   marks?: Omit<CustomText, 'text'>;
 }) => {
   return (
     <span
-      className="plait-latex-block"
+      className={displayMode ? 'plait-latex-block' : 'plait-latex-inline'}
       style={{ color: marks?.color }}
-      dangerouslySetInnerHTML={{ __html: renderLatexToString(formula) }}
+      dangerouslySetInnerHTML={{
+        __html: renderLatexFormulaToString(formula, displayMode),
+      }}
     />
   );
 };
@@ -361,4 +400,42 @@ const getLeafStyle = (leaf: Omit<CustomText, 'text'>): CSSProperties => {
         .filter(Boolean)
         .join(' ') || undefined,
   };
+};
+
+const isDomSelectionInside = (container: HTMLElement) => {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || !selection.toString()) {
+    return false;
+  }
+
+  const anchorNode = selection.anchorNode;
+  const focusNode = selection.focusNode;
+  return (
+    (!!anchorNode && container.contains(anchorNode)) ||
+    (!!focusNode && container.contains(focusNode))
+  );
+};
+
+const writePlainTextClipboard = (
+  clipboardData: DataTransfer | null,
+  text: string
+) => {
+  if (!clipboardData) {
+    return;
+  }
+
+  clipboardData.setData('text/plain', text);
+  clipboardData.setData(
+    'text/html',
+    `<pre style="white-space: pre-wrap;">${escapeHtml(text)}</pre>`
+  );
+};
+
+const escapeHtml = (text: string) => {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 };

--- a/packages/react-text/src/text.tsx
+++ b/packages/react-text/src/text.tsx
@@ -291,7 +291,7 @@ const LatexBlock = ({
   return (
     <span
       className={displayMode ? 'plait-latex-block' : 'plait-latex-inline'}
-      style={{ color: marks?.color }}
+      style={marks ? getLeafStyle(marks) : undefined}
       dangerouslySetInnerHTML={{
         __html: renderLatexFormulaToString(formula, displayMode),
       }}
@@ -350,11 +350,16 @@ const renderTextRange = (
       if (leaf.url) {
         return (
           <a
-            className="drawnix-link"
+            className="plait-board-link"
+            data-url={leaf.url}
             href={leaf.url}
             key={key}
             rel="noreferrer"
-            style={style}
+            style={{
+              ...style,
+              cursor: 'inherit',
+              textDecoration: 'none',
+            }}
             target="_blank"
           >
             {content}
@@ -383,7 +388,7 @@ const getMarksAtOffset = (
   leaves: FlattenedTextLeaf[],
   offset: number
 ): Omit<CustomText, 'text'> | undefined => {
-  return leaves.find((leaf) => leaf.start <= offset && leaf.end >= offset)
+  return leaves.find((leaf) => leaf.start <= offset && offset < leaf.end)
     ?.marks;
 };
 

--- a/packages/react-text/src/text.tsx
+++ b/packages/react-text/src/text.tsx
@@ -1,4 +1,12 @@
-import { createEditor, type Descendant, Range, Transforms } from 'slate';
+import {
+  createEditor,
+  type Descendant,
+  Element as SlateElement,
+  Node,
+  Range,
+  Text as SlateText,
+  Transforms,
+} from 'slate';
 import { isKeyHotkey } from 'is-hotkey';
 import {
   Editable,
@@ -22,6 +30,12 @@ import { CustomEditor, RenderElementPropsFor } from './custom-types';
 
 import './styles/index.scss';
 import { LinkComponent, withInlineLink } from './plugins/with-link';
+import {
+  hasLatexBlocksInTextElement,
+  parseLatexBlocks,
+  renderLatexToString,
+} from './latex';
+import 'katex/dist/katex.min.css';
 
 export type TextComponentProps = TextProps;
 
@@ -29,6 +43,8 @@ export const Text: React.FC<TextComponentProps> = (
   props: TextComponentProps
 ) => {
   const { text, readonly, onChange, onComposition, afterInit } = props;
+
+  const isReadonly = readonly === undefined ? true : readonly;
 
   const renderLeaf = useCallback(
     (props: RenderLeafProps) => <Leaf {...props} />,
@@ -91,9 +107,11 @@ export const Text: React.FC<TextComponentProps> = (
     >
       <Editable
         className="slate-editable-container plait-text-container"
-        renderElement={(props) => <Element {...props} />}
+        renderElement={(props) => (
+          <Element {...props} renderLatex={isReadonly} />
+        )}
         renderLeaf={renderLeaf}
-        readOnly={readonly === undefined ? true : readonly}
+        readOnly={isReadonly}
         onCompositionStart={(event) => {
           if (onComposition) {
             onComposition(event as unknown as CompositionEvent);
@@ -115,10 +133,16 @@ export const Text: React.FC<TextComponentProps> = (
   );
 };
 
-const Element = (props: RenderElementProps) => {
+const Element = (
+  props: RenderElementProps & {
+    renderLatex: boolean;
+  }
+) => {
   const { attributes, children, element } = props as RenderElementPropsFor<
     CustomElement & { type: string }
-  >;
+  > & {
+    renderLatex: boolean;
+  };
   switch (element.type) {
     case 'link':
       return (
@@ -128,6 +152,7 @@ const Element = (props: RenderElementProps) => {
       return (
         <ParagraphComponent
           {...(props as RenderElementPropsFor<ParagraphElement>)}
+          renderLatex={props.renderLatex}
         />
       );
   }
@@ -137,11 +162,20 @@ const ParagraphComponent = ({
   attributes,
   children,
   element,
-}: RenderElementPropsFor<ParagraphElement>) => {
+  renderLatex,
+}: RenderElementPropsFor<ParagraphElement> & { renderLatex: boolean }) => {
   const style = { textAlign: element.align } as CSSProperties;
+  const shouldRenderLatex = renderLatex && hasLatexBlocksInTextElement(element);
   return (
     <div style={style} {...attributes}>
-      {children}
+      {shouldRenderLatex ? (
+        <>
+          <LatexTextContent element={element} />
+          <span hidden>{children}</span>
+        </>
+      ) : (
+        children
+      )}
     </div>
   );
 };
@@ -165,7 +199,7 @@ const Leaf: React.FC<RenderLeafProps> = ({ children, leaf, attributes }) => {
 
   const fontSizeValue = (leaf as CustomText)['font-size'];
   const style: CSSProperties = {
-    color: (leaf as CustomText).color
+    color: (leaf as CustomText).color,
   };
 
   return (
@@ -177,4 +211,154 @@ const Leaf: React.FC<RenderLeafProps> = ({ children, leaf, attributes }) => {
       {children}
     </span>
   );
+};
+
+type FlattenedTextLeaf = {
+  end: number;
+  marks: Omit<CustomText, 'text'>;
+  start: number;
+  text: string;
+  url?: string;
+};
+
+const LatexTextContent = ({ element }: { element: ParagraphElement }) => {
+  const leaves = flattenTextLeaves(element);
+  const text = Node.string(element);
+  const segments = parseLatexBlocks(text);
+  return (
+    <span className="plait-latex-text-container">
+      {segments.map((segment, index) => {
+        if (segment.type === 'latex') {
+          const marks = getMarksAtOffset(leaves, segment.start);
+          return (
+            <LatexBlock
+              formula={segment.formula}
+              key={`${segment.start}-${index}`}
+              marks={marks}
+            />
+          );
+        }
+        return renderTextRange(leaves, segment.start, segment.end, index);
+      })}
+    </span>
+  );
+};
+
+const LatexBlock = ({
+  formula,
+  marks,
+}: {
+  formula: string;
+  marks?: Omit<CustomText, 'text'>;
+}) => {
+  return (
+    <span
+      className="plait-latex-block"
+      style={{ color: marks?.color }}
+      dangerouslySetInnerHTML={{ __html: renderLatexToString(formula) }}
+    />
+  );
+};
+
+const flattenTextLeaves = (element: ParagraphElement) => {
+  const leaves: FlattenedTextLeaf[] = [];
+  let offset = 0;
+
+  const visit = (node: Node, inheritedUrl?: string) => {
+    if (SlateText.isText(node)) {
+      const text = node.text;
+      const start = offset;
+      offset += text.length;
+      leaves.push({
+        end: offset,
+        marks: node,
+        start,
+        text,
+        url: inheritedUrl,
+      });
+      return;
+    }
+
+    if (SlateElement.isElement(node)) {
+      const url =
+        (node as LinkElement).type === 'link'
+          ? (node as LinkElement).url
+          : inheritedUrl;
+      node.children.forEach((child) => visit(child, url));
+    }
+  };
+
+  visit(element);
+  return leaves;
+};
+
+const renderTextRange = (
+  leaves: FlattenedTextLeaf[],
+  start: number,
+  end: number,
+  segmentIndex: number
+) => {
+  return leaves
+    .filter((leaf) => leaf.end > start && leaf.start < end)
+    .map((leaf, index) => {
+      const sliceStart = Math.max(start, leaf.start) - leaf.start;
+      const sliceEnd = Math.min(end, leaf.end) - leaf.start;
+      const text = leaf.text.slice(sliceStart, sliceEnd);
+      const content = renderTextWithBreaks(text);
+      const style = getLeafStyle(leaf.marks);
+      const key = `${segmentIndex}-${leaf.start}-${index}`;
+
+      if (leaf.url) {
+        return (
+          <a
+            className="drawnix-link"
+            href={leaf.url}
+            key={key}
+            rel="noreferrer"
+            style={style}
+            target="_blank"
+          >
+            {content}
+          </a>
+        );
+      }
+
+      return (
+        <span key={key} style={style}>
+          {content}
+        </span>
+      );
+    });
+};
+
+const renderTextWithBreaks = (text: string) => {
+  return text.split('\n').map((line, index, lines) => (
+    <React.Fragment key={`${index}-${line}`}>
+      {line}
+      {index < lines.length - 1 && <br />}
+    </React.Fragment>
+  ));
+};
+
+const getMarksAtOffset = (
+  leaves: FlattenedTextLeaf[],
+  offset: number
+): Omit<CustomText, 'text'> | undefined => {
+  return leaves.find((leaf) => leaf.start <= offset && leaf.end >= offset)
+    ?.marks;
+};
+
+const getLeafStyle = (leaf: Omit<CustomText, 'text'>): CSSProperties => {
+  const fontSizeValue = leaf['font-size'];
+  return {
+    color: leaf.color,
+    fontSize: fontSizeValue ? `${fontSizeValue}px` : undefined,
+    fontStyle: leaf.italic ? 'italic' : undefined,
+    fontWeight: leaf.bold ? 'bold' : undefined,
+    lineHeight: fontSizeValue ? 1.5 : undefined,
+    textDecoration:
+      [leaf.underlined ? 'underline' : '', leaf.strike ? 'line-through' : '']
+        .filter(Boolean)
+        .join(' ') || undefined,
+  };
 };

--- a/packages/react-text/vite.config.ts
+++ b/packages/react-text/vite.config.ts
@@ -43,7 +43,18 @@ export default defineConfig({
     },
     rollupOptions: {
       // External packages that should not be bundled into your library.
-      external: ['react', 'react-dom', 'react/jsx-runtime', 'slate', 'slate-react', 'slate-history', 'is-hotkey', '@plait/text-plugins', '@plait/common'],
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'slate',
+        'slate-react',
+        'slate-history',
+        'is-hotkey',
+        'katex',
+        '@plait/text-plugins',
+        '@plait/common',
+      ],
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

Closes #251

This PR adds LaTeX rendering support for text elements and mind nodes.

Supported syntax:

- Inline LaTeX with `\( ... \)`
- Block LaTeX with `\[ ... \]`

Legacy dollar-delimited syntax such as `$...$` and `$$...$$` is intentionally not rendered.

## Changes

- Parse inline and block LaTeX segments in rich text content.
- Render LaTeX with KaTeX inside normal text elements and mind nodes.
- Keep LaTeX source editable when entering text edit mode.
- Update text and mind node measurement so rendered LaTeX uses the correct element size after editing.
- Preserve LaTeX styling when copying, pasting, and exporting rendered content.
- Add test coverage for LaTeX parsing and rendering behavior.

## Testing

Manually tested:

- Inline LaTeX rendering in text elements.
- Block LaTeX rendering in text elements.
- Mixed plain text, inline LaTeX, and block LaTeX.
- LaTeX rendering in mind nodes.
- Editing rendered LaTeX and exiting edit mode.
- Copying and pasting rendered LaTeX elements.
- Exporting rendered LaTeX and checking visual consistency.
- Confirmed unsupported `$...$`, `$$...$$`, and legacy `\latex ... \endlatex` syntax remain plain text.

Automated checks:

- `npx.cmd jest -c packages\react-text\jest.config.ts --runInBand --verbose`
- `npx.cmd vite build --config packages\drawnix\vite.config.ts`

Note: `tsc` still reports existing freehand-related type errors that are unrelated to this PR.
