### PR TITLE
fix: split save and save as file actions

### DIFF
--- a/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
+++ b/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
@@ -14,7 +14,7 @@ import {
   ThemeColorMode,
   Viewport,
 } from '@plait/core';
-import { loadFromJSON, saveAsJSON } from '../../../data/json';
+import { loadFromJSON, saveAsJSON, saveJSON } from '../../../data/json';
 import MenuItem from '../../menu/menu-item';
 import MenuItemLink from '../../menu/menu-item-link';
 import { saveAsImage, saveAsSvg } from '../../../utils/image';
@@ -28,12 +28,18 @@ import { getShortcutKey } from '../../../utils/common';
 
 export const SaveToFile = () => {
   const board = useBoard();
+  const { appState, setAppState } = useDrawnix();
   const { t } = useI18n();
   return (
     <MenuItem
       data-testid="save-button"
       onSelect={() => {
-        saveAsJSON(board);
+        saveJSON(board, appState.fileHandle).then(({ fileHandle }) => {
+          setAppState((currentAppState) => ({
+            ...currentAppState,
+            fileHandle,
+          }));
+        });
       }}
       icon={SaveFileIcon}
       aria-label={t('menu.saveFile')}
@@ -43,9 +49,33 @@ export const SaveToFile = () => {
 };
 SaveToFile.displayName = 'SaveToFile';
 
+export const SaveAsFile = () => {
+  const board = useBoard();
+  const { setAppState } = useDrawnix();
+  const { t } = useI18n();
+  return (
+    <MenuItem
+      data-testid="save-as-button"
+      onSelect={() => {
+        saveAsJSON(board).then(({ fileHandle }) => {
+          setAppState((currentAppState) => ({
+            ...currentAppState,
+            fileHandle,
+          }));
+        });
+      }}
+      icon={SaveFileIcon}
+      aria-label={t('menu.saveAsFile')}
+      shortcut={getShortcutKey('CtrlOrCmd+Shift+S')}
+    >{t('menu.saveAsFile')}</MenuItem>
+  );
+};
+SaveAsFile.displayName = 'SaveAsFile';
+
 export const OpenFile = () => {
   const board = useBoard();
   const listRender = useListRender();
+  const { setAppState } = useDrawnix();
   const { t } = useI18n();
   const clearAndLoad = (
     value: PlaitElement[],
@@ -68,8 +98,12 @@ export const OpenFile = () => {
     <MenuItem
       data-testid="open-button"
       onSelect={() => {
-        loadFromJSON(board).then((data) => {
+        loadFromJSON(board).then(({ data, fileHandle }) => {
           clearAndLoad(data.elements, data.viewport, data.theme);
+          setAppState((currentAppState) => ({
+            ...currentAppState,
+            fileHandle,
+          }));
         });
       }}
       icon={OpenFileIcon}

--- a/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
+++ b/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
@@ -30,6 +30,9 @@ export const SaveToFile = () => {
   const board = useBoard();
   const { appState, setAppState } = useDrawnix();
   const { t } = useI18n();
+  if (!appState.fileHandle) {
+    return null;
+  }
   return (
     <MenuItem
       data-testid="save-button"

--- a/packages/drawnix/src/components/toolbar/app-toolbar/app-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/app-toolbar/app-toolbar.tsx
@@ -19,7 +19,14 @@ import {
 import { Island } from '../../island';
 import { Popover, PopoverContent, PopoverTrigger } from '../../popover/popover';
 import { useState } from 'react';
-import { CleanBoard, OpenFile, SaveAsImage, SaveToFile, Socials } from './app-menu-items';
+import {
+  CleanBoard,
+  OpenFile,
+  SaveAsFile,
+  SaveAsImage,
+  SaveToFile,
+  Socials,
+} from './app-menu-items';
 import { LanguageSwitcherMenu } from './language-switcher-menu';
 import Menu from '../../menu/menu';
 import MenuSeparator from '../../menu/menu-separator';
@@ -69,6 +76,7 @@ export const AppToolbar = () => {
             >
               <OpenFile></OpenFile>
               <SaveToFile></SaveToFile>
+              <SaveAsFile></SaveAsFile>
               <SaveAsImage></SaveAsImage>
               <CleanBoard></CleanBoard>
               <MenuSeparator />

--- a/packages/drawnix/src/data/filesystem.ts
+++ b/packages/drawnix/src/data/filesystem.ts
@@ -1,4 +1,4 @@
-import type { FileSystemHandle } from 'browser-fs-access';
+import type { FileSystemHandle as BrowserFileSystemHandle } from 'browser-fs-access';
 import {
   fileOpen as _fileOpen,
   fileSave as _fileSave,
@@ -7,6 +7,8 @@ import {
 import { MIME_TYPES } from '../constants';
 
 type FILE_EXTENSION = Exclude<keyof typeof MIME_TYPES, 'binary'>;
+
+export type FileSystemHandle = BrowserFileSystemHandle | FileSystemFileHandle;
 
 export const fileOpen = <M extends boolean | undefined = false>(opts: {
   extensions?: FILE_EXTENSION[];
@@ -60,5 +62,4 @@ export const fileSave = (
   );
 };
 
-export type { FileSystemHandle };
 export { nativeFileSystemSupported };

--- a/packages/drawnix/src/data/json.ts
+++ b/packages/drawnix/src/data/json.ts
@@ -1,8 +1,14 @@
 import { PlaitBoard, PlaitElement } from '@plait/core';
 import { MIME_TYPES, VERSIONS } from '../constants';
-import { fileOpen, fileSave } from './filesystem';
+import { fileOpen, fileSave, type FileSystemHandle } from './filesystem';
 import { DrawnixExportedData, DrawnixExportedType } from './types';
 import { loadFromBlob, normalizeFile } from './blob';
+
+export type DrawnixFileHandle = FileSystemHandle | null;
+
+type FileWithHandle = File & {
+  handle?: FileSystemHandle;
+};
 
 export const getDefaultName = () => {
   const time = new Date().getTime();
@@ -11,6 +17,14 @@ export const getDefaultName = () => {
 
 export const saveAsJSON = async (
   board: PlaitBoard,
+  name: string = getDefaultName()
+) => {
+  return saveJSON(board, null, name);
+};
+
+export const saveJSON = async (
+  board: PlaitBoard,
+  existingFileHandle: DrawnixFileHandle = null,
   name: string = getDefaultName()
 ) => {
   const serialized = serializeAsJSON(board);
@@ -22,6 +36,7 @@ export const saveAsJSON = async (
     name,
     extension: 'drawnix',
     description: 'Drawnix file',
+    fileHandle: existingFileHandle,
   });
   return { fileHandle };
 };
@@ -33,7 +48,9 @@ export const loadFromJSON = async (board: PlaitBoard) => {
     // gets resolved. Else, iOS users cannot open `.drawnix` files.
     // extensions: ["json", "drawnix", "png", "svg"],
   });
-  return loadFromBlob(board, await normalizeFile(file));
+  const fileHandle = (file as FileWithHandle).handle || null;
+  const data = await loadFromBlob(board, await normalizeFile(file));
+  return { data, fileHandle };
 };
 
 export const isValidDrawnixData = (data?: any): data is DrawnixExportedData => {

--- a/packages/drawnix/src/drawnix.tsx
+++ b/packages/drawnix/src/drawnix.tsx
@@ -85,6 +85,7 @@ export const Drawnix: React.FC<DrawnixProps> = ({
         ...preset,
       })),
       activeFreehandPresetIndex: 0,
+      fileHandle: null,
       openDialogType: null,
       openCleanConfirm: false,
     };

--- a/packages/drawnix/src/hooks/use-drawnix.tsx
+++ b/packages/drawnix/src/hooks/use-drawnix.tsx
@@ -15,6 +15,7 @@ import { FreehandShape } from '../plugins/freehand/type';
 import { Editor } from 'slate';
 import { LinkElement } from '@plait/common';
 import { FreehandDrawOptions } from '../plugins/freehand/presets';
+import { DrawnixFileHandle } from '../data/json';
 
 export enum DialogType {
   mermaidToDrawnix = 'mermaidToDrawnix',
@@ -46,6 +47,7 @@ export type DrawnixState = {
   isPencilMode: boolean;
   freehandPresets: FreehandDrawOptions[];
   activeFreehandPresetIndex: number;
+  fileHandle: DrawnixFileHandle;
   openDialogType: DialogType | null;
   openCleanConfirm: boolean;
   linkState?: LinkState | null;

--- a/packages/drawnix/src/i18n/translations/ar.ts
+++ b/packages/drawnix/src/i18n/translations/ar.ts
@@ -83,7 +83,7 @@ const arTranslations: Translations = {
 
     // Menu items
     "menu.open": "فتح",
-    "menu.saveFile": "حفظ الملف",
+    "menu.saveFile": "حفظ إلى الملف الحالي",
     "menu.saveAsFile": "حفظ باسم",
     "menu.exportImage": "تصدير صورة",
     "menu.exportImage.svg": "SVG",

--- a/packages/drawnix/src/i18n/translations/ar.ts
+++ b/packages/drawnix/src/i18n/translations/ar.ts
@@ -84,6 +84,7 @@ const arTranslations: Translations = {
     // Menu items
     "menu.open": "فتح",
     "menu.saveFile": "حفظ الملف",
+    "menu.saveAsFile": "حفظ باسم",
     "menu.exportImage": "تصدير صورة",
     "menu.exportImage.svg": "SVG",
     "menu.exportImage.png": "PNG",

--- a/packages/drawnix/src/i18n/translations/en.ts
+++ b/packages/drawnix/src/i18n/translations/en.ts
@@ -82,6 +82,7 @@ const enTranslations: Translations = {
   // Menu items
   'menu.open': 'Open',
   'menu.saveFile': 'Save File',
+  'menu.saveAsFile': 'Save As',
   'menu.exportImage': 'Export Image',
   'menu.exportImage.svg': 'SVG',
   'menu.exportImage.png': 'PNG',

--- a/packages/drawnix/src/i18n/translations/en.ts
+++ b/packages/drawnix/src/i18n/translations/en.ts
@@ -81,7 +81,7 @@ const enTranslations: Translations = {
   'language.vietnamese': 'Tiếng Việt',
   // Menu items
   'menu.open': 'Open',
-  'menu.saveFile': 'Save File',
+  'menu.saveFile': 'Save to current file',
   'menu.saveAsFile': 'Save As',
   'menu.exportImage': 'Export Image',
   'menu.exportImage.svg': 'SVG',

--- a/packages/drawnix/src/i18n/translations/ru.ts
+++ b/packages/drawnix/src/i18n/translations/ru.ts
@@ -83,7 +83,7 @@ const ruTranslations: Translations = {
 
   // Menu items
   'menu.open': 'Открыть',
-  'menu.saveFile': 'Сохранить',
+  'menu.saveFile': 'Сохранить в текущий файл',
   'menu.saveAsFile': 'Сохранить как',
   'menu.exportImage': 'Экспортировать',
   'menu.exportImage.svg': 'SVG',

--- a/packages/drawnix/src/i18n/translations/ru.ts
+++ b/packages/drawnix/src/i18n/translations/ru.ts
@@ -84,6 +84,7 @@ const ruTranslations: Translations = {
   // Menu items
   'menu.open': 'Открыть',
   'menu.saveFile': 'Сохранить',
+  'menu.saveAsFile': 'Сохранить как',
   'menu.exportImage': 'Экспортировать',
   'menu.exportImage.svg': 'SVG',
   'menu.exportImage.png': 'PNG',

--- a/packages/drawnix/src/i18n/translations/vi.ts
+++ b/packages/drawnix/src/i18n/translations/vi.ts
@@ -83,7 +83,7 @@ const viTranslations: Translations = {
 
     // Menu items
     'menu.open': 'Mở',
-    'menu.saveFile': 'Lưu tệp',
+    'menu.saveFile': 'Lưu vào tệp hiện tại',
     'menu.saveAsFile': 'Lưu thành',
     'menu.exportImage': 'Xuất hình ảnh',
     'menu.exportImage.svg': 'SVG',

--- a/packages/drawnix/src/i18n/translations/vi.ts
+++ b/packages/drawnix/src/i18n/translations/vi.ts
@@ -84,6 +84,7 @@ const viTranslations: Translations = {
     // Menu items
     'menu.open': 'Mở',
     'menu.saveFile': 'Lưu tệp',
+    'menu.saveAsFile': 'Lưu thành',
     'menu.exportImage': 'Xuất hình ảnh',
     'menu.exportImage.svg': 'SVG',
     'menu.exportImage.png': 'PNG',

--- a/packages/drawnix/src/i18n/translations/zh.ts
+++ b/packages/drawnix/src/i18n/translations/zh.ts
@@ -82,7 +82,7 @@ const zhTranslations: Translations = {
   'language.vietnamese': 'Tiếng Việt',
   // Menu items
   'menu.open': '打开',
-  'menu.saveFile': '保存文件',
+  'menu.saveFile': '保存到当前文件',
   'menu.saveAsFile': '另存为',
   'menu.exportImage': '导出图片',
   'menu.exportImage.svg': 'SVG',

--- a/packages/drawnix/src/i18n/translations/zh.ts
+++ b/packages/drawnix/src/i18n/translations/zh.ts
@@ -83,6 +83,7 @@ const zhTranslations: Translations = {
   // Menu items
   'menu.open': '打开',
   'menu.saveFile': '保存文件',
+  'menu.saveAsFile': '另存为',
   'menu.exportImage': '导出图片',
   'menu.exportImage.svg': 'SVG',
   'menu.exportImage.png': 'PNG',

--- a/packages/drawnix/src/i18n/types.ts
+++ b/packages/drawnix/src/i18n/types.ts
@@ -87,6 +87,7 @@ export interface Translations {
   // Menu items
   'menu.open': string;
   'menu.saveFile': string;
+  'menu.saveAsFile': string;
   'menu.exportImage': string;
   'menu.exportImage.svg': string;
   'menu.exportImage.png': string;

--- a/packages/drawnix/src/plugins/with-hotkey.ts
+++ b/packages/drawnix/src/plugins/with-hotkey.ts
@@ -6,8 +6,8 @@ import {
 } from '@plait/core';
 import { isHotkey } from 'is-hotkey';
 import { addImage, saveAsImage } from '../utils/image';
-import { saveAsJSON } from '../data/json';
-import { DrawnixState } from '../hooks/use-drawnix';
+import { saveAsJSON, saveJSON } from '../data/json';
+import { DrawnixBoard, DrawnixState } from '../hooks/use-drawnix';
 import { BoardCreationMode, setCreationMode } from '@plait/common';
 import { MindPointerType } from '@plait/mind';
 import { FreehandShape } from './freehand/type';
@@ -33,8 +33,19 @@ export const buildDrawnixHotkeyPlugin = (
           event.preventDefault();
           return;
         }
+        if (isHotkey(['mod+shift+s'], { byKey: true })(event)) {
+          saveAsJSON(board).then(({ fileHandle }) => {
+            updateAppState({ fileHandle });
+          });
+          event.preventDefault();
+          return;
+        }
         if (isHotkey(['mod+s'], { byKey: true })(event)) {
-          saveAsJSON(board);
+          saveJSON(board, (board as DrawnixBoard).appState.fileHandle).then(
+            ({ fileHandle }) => {
+              updateAppState({ fileHandle });
+            }
+          );
           event.preventDefault();
           return;
         }


### PR DESCRIPTION
## Summary

- Split the Drawnix file menu into separate Save File and Save As actions.
- Reuse the current File System Access handle for Save File and Ctrl/Cmd+S so repeated saves update the same .drawnix file.
- Keep Save As and Ctrl/Cmd+Shift+S opening a fresh save dialog, and preserve the opened file handle after loading a .drawnix file.
- Add the new Save As menu label to the existing i18n translations.

## Validation

- npx.cmd nx build drawnix

Closes #296