### PR TITLE
feat(more-options): improve more-options

### DIFF
--- a/packages/drawnix/src/components/toolbar/popup-toolbar/more-options-button.tsx
+++ b/packages/drawnix/src/components/toolbar/popup-toolbar/more-options-button.tsx
@@ -3,7 +3,7 @@ import { ToolButton } from '../../tool-button';
 import classNames from 'classnames';
 import { useI18n } from '../../../i18n';
 import { deleteFragment, duplicateElements, PlaitBoard } from '@plait/core';
-import { DuplicateIcon, MoreOptionsIcon, TrashIcon } from '../../icons';
+import { MoreOptionsIcon } from '../../icons';
 import { Popover, PopoverContent, PopoverTrigger } from '../../popover/popover';
 import Menu from '../../menu/menu';
 import MenuItem from '../../menu/menu-item';
@@ -63,7 +63,6 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({
             onSelect={() => {
               duplicateElements(board);
             }}
-            icon={DuplicateIcon}
             shortcut={getShortcutKey('CtrlOrCmd+D')}
             aria-label={t('general.duplicate')}
           >
@@ -73,7 +72,6 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({
             onSelect={() => {
               deleteFragment(board);
             }}
-            icon={TrashIcon}
             shortcut={getShortcutKey('Backspace')}
             aria-label={t('general.delete')}
           >
@@ -81,6 +79,7 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({
           </MenuItem>
           <MenuItem
             onSelect={() => undefined}
+            shortcut={getShortcutKey('Shift+Option+C')}
             aria-label={t('general.copyToClipboard')}
             disabled={!canCopyAny}
             submenu={
@@ -91,7 +90,7 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({
               >
                 <MenuItem
                   onSelect={() => {
-                    void copySelectionAsSvg(board).catch(() => undefined);
+                    copySelectionAsSvg(board).catch(() => undefined);
                   }}
                   disabled={!canCopySvg}
                   aria-label={t('general.copyToClipboard.svg')}
@@ -100,7 +99,7 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({
                 </MenuItem>
                 <MenuItem
                   onSelect={() => {
-                    void copySelectionAsPng(board).catch(() => undefined);
+                    copySelectionAsPng(board).catch(() => undefined);
                   }}
                   disabled={!canCopyPng}
                   aria-label={t('general.copyToClipboard.pngWithoutBackground')}
@@ -109,7 +108,7 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({
                 </MenuItem>
                 <MenuItem
                   onSelect={() => {
-                    void copySelectionAsPng(board, true).catch(() => undefined);
+                    copySelectionAsPng(board, true).catch(() => undefined);
                   }}
                   disabled={!canCopyPng}
                   aria-label={t('general.copyToClipboard.pngWithBackground')}

--- a/packages/drawnix/src/components/toolbar/popup-toolbar/more-options-button.tsx
+++ b/packages/drawnix/src/components/toolbar/popup-toolbar/more-options-button.tsx
@@ -79,7 +79,7 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({
           </MenuItem>
           <MenuItem
             onSelect={() => undefined}
-            shortcut={getShortcutKey('Shift+Option+C')}
+            shortcut={getShortcutKey('Shift+Alt+C')}
             aria-label={t('general.copyToClipboard')}
             disabled={!canCopyAny}
             submenu={

--- a/packages/drawnix/src/i18n/translations/zh.ts
+++ b/packages/drawnix/src/i18n/translations/zh.ts
@@ -65,7 +65,7 @@ const zhTranslations: Translations = {
   'general.redo': '重做',
   'general.menu': '应用菜单',
   'general.moreOptions': '更多选项',
-  'general.duplicate': '复制',
+  'general.duplicate': '重复',
   'general.delete': '删除',
 
   'general.copyToClipboard': '复制到剪贴板',

--- a/packages/drawnix/src/plugins/with-hotkey.ts
+++ b/packages/drawnix/src/plugins/with-hotkey.ts
@@ -5,7 +5,13 @@ import {
   PlaitPointerType,
 } from '@plait/core';
 import { isHotkey } from 'is-hotkey';
-import { addImage, copySelectionAsSvg, saveAsImage } from '../utils/image';
+import {
+  addImage,
+  canCopySelectionAs,
+  copySelectionAsPng,
+  copySelectionAsSvg,
+  saveAsImage,
+} from '../utils/image';
 import { saveAsJSON, saveJSON } from '../data/json';
 import { DrawnixBoard, DrawnixState } from '../hooks/use-drawnix';
 import { BoardCreationMode, setCreationMode } from '@plait/common';
@@ -129,8 +135,17 @@ export const buildDrawnixHotkeyPlugin = (
           }
         }
         if (isHotkey('shift+alt+c')(event)) {
-          copySelectionAsSvg(board).catch(() => undefined);
-          event.preventDefault();
+          const canCopySvg = canCopySelectionAs('svg');
+          const canCopyPng = canCopySelectionAs('png');
+          if (canCopySvg || canCopyPng) {
+            if (canCopySvg) {
+              copySelectionAsSvg(board).catch(() => undefined);
+            } else if (canCopyPng) {
+              copySelectionAsPng(board).catch(() => undefined);
+            }
+            event.preventDefault();
+          }
+
           return;
         }
       }

--- a/packages/drawnix/src/plugins/with-hotkey.ts
+++ b/packages/drawnix/src/plugins/with-hotkey.ts
@@ -5,7 +5,7 @@ import {
   PlaitPointerType,
 } from '@plait/core';
 import { isHotkey } from 'is-hotkey';
-import { addImage, saveAsImage } from '../utils/image';
+import { addImage, copySelectionAsSvg, saveAsImage } from '../utils/image';
 import { saveAsJSON, saveJSON } from '../data/json';
 import { DrawnixBoard, DrawnixState } from '../hooks/use-drawnix';
 import { BoardCreationMode, setCreationMode } from '@plait/common';
@@ -127,6 +127,11 @@ export const buildDrawnixHotkeyPlugin = (
             event.preventDefault();
             return;
           }
+        }
+        if (isHotkey('shift+alt+c')(event)) {
+          copySelectionAsSvg(board).catch(() => undefined);
+          event.preventDefault();
+          return;
         }
       }
       globalKeyDown(event);


### PR DESCRIPTION
1. remove icon on the item of  more-options, it's weird that the last item don't have icon so I think it's simple and uniform to remove icon for items
2. add shortcuts for copy svg as clipboard, I also plan to move submenu(svg/png) to fist level, it would be clearer
3. Change duplicate action label from '复制' to '重复' in Chinese locale to resolve naming conflict with clipboard copy (Ctrl+C).

Before:
<img width="1502" height="541" alt="Screenshot 2026-06-10 at 20 19 14" src="https://github.com/user-attachments/assets/16d51769-5a23-42d7-adb5-3f5d0fe9d262" />
After:
<img width="1502" height="541" alt="Screenshot 2026-06-10 at 20 21 13" src="https://github.com/user-attachments/assets/a176fd5e-cf08-49dc-93cd-1dec41cb34de" />

