### PR TITLE
feat: persist selected tool state

### DIFF
--- a/apps/web/src/app/app.tsx
+++ b/apps/web/src/app/app.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Drawnix } from '@drawnix/drawnix';
+import { Drawnix, DrawnixToolState } from '@drawnix/drawnix';
 import { PlaitBoard, PlaitElement, PlaitTheme, Viewport } from '@plait/core';
 import localforage from 'localforage';
 
@@ -10,6 +10,7 @@ type AppValue = {
 };
 
 const MAIN_BOARD_CONTENT_KEY = 'main_board_content';
+const MAIN_BOARD_TOOL_STATE_KEY = 'main_board_tool_state';
 
 localforage.config({
   name: 'Drawnix',
@@ -19,30 +20,43 @@ localforage.config({
 
 export function App() {
   const [value, setValue] = useState<AppValue>({ children: [] });
+  const [initialToolState, setInitialToolState] =
+    useState<Partial<DrawnixToolState>>();
+  const [loaded, setLoaded] = useState(false);
 
   const [tutorial, setTutorial] = useState(false);
 
   useEffect(() => {
     const loadData = async () => {
-      const storedData = (await localforage.getItem(
-        MAIN_BOARD_CONTENT_KEY
-      )) as AppValue;
+      const [storedData, storedToolState] = await Promise.all([
+        localforage.getItem(MAIN_BOARD_CONTENT_KEY),
+        localforage.getItem(MAIN_BOARD_TOOL_STATE_KEY),
+      ]);
       if (storedData) {
-        setValue(storedData);
-        if (storedData.children && storedData.children.length === 0) {
+        const appValue = storedData as AppValue;
+        setValue(appValue);
+        if (appValue.children && appValue.children.length === 0) {
           setTutorial(true);
         }
-        return;
+      } else {
+        setTutorial(true);
       }
-      setTutorial(true);
+      if (storedToolState) {
+        setInitialToolState(storedToolState as Partial<DrawnixToolState>);
+      }
+      setLoaded(true);
     };
     loadData();
   }, []);
+  if (!loaded) {
+    return null;
+  }
   return (
     <Drawnix
       value={value.children}
       viewport={value.viewport}
       theme={value.theme}
+      initialToolState={initialToolState}
       onChange={(value) => {
         const newValue = value as AppValue;
         localforage.setItem(MAIN_BOARD_CONTENT_KEY, newValue);
@@ -50,6 +64,9 @@ export function App() {
         if (newValue.children && newValue.children.length > 0) {
           setTutorial(false);
         }
+      }}
+      onToolStateChange={(toolState) => {
+        localforage.setItem(MAIN_BOARD_TOOL_STATE_KEY, toolState);
       }}
       tutorial={tutorial}
       afterInit={(board) => {

--- a/packages/drawnix/src/components/popover/popover.tsx
+++ b/packages/drawnix/src/components/popover/popover.tsx
@@ -162,8 +162,11 @@ export const PopoverTrigger = React.forwardRef<
 
 export const PopoverContent = React.forwardRef<
   HTMLDivElement,
-  React.HTMLProps<HTMLDivElement> & { container?: HTMLElement | null }
->(function PopoverContent({ container, style, ...props }, propRef) {
+  React.HTMLProps<HTMLDivElement> & {
+    container?: HTMLElement | null;
+    initialFocus?: number | React.MutableRefObject<HTMLElement | null>;
+  }
+>(function PopoverContent({ container, initialFocus, style, ...props }, propRef) {
   const { context: floatingContext, ...context } = usePopoverContext();
   const ref = useMergeRefs([context.refs.setFloating, propRef]);
 
@@ -171,7 +174,11 @@ export const PopoverContent = React.forwardRef<
 
   return (
     <FloatingPortal root={container}>
-      <FloatingFocusManager context={floatingContext} modal={context.modal}>
+      <FloatingFocusManager
+        context={floatingContext}
+        modal={context.modal}
+        initialFocus={initialFocus}
+      >
         <div
           ref={ref}
           style={{ ...context.floatingStyles, ...style }}

--- a/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
@@ -31,7 +31,7 @@ import {
 import { FreehandPanel } from './freehand-panel/freehand-panel';
 import { ShapePicker } from '../shape-picker';
 import { ArrowPicker } from '../arrow-picker';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '../popover/popover';
 import { FreehandShape } from '../../plugins/freehand/type';
 import {
@@ -120,13 +120,31 @@ export const BUTTONS: AppToolButtonProps[] = [
 
 // TODO provider by plait/draw
 export const isArrowLinePointer = (board: PlaitBoard) => {
-  return Object.keys(ArrowLineShape).includes(board.pointer);
+  return isArrowLinePointerType(board.pointer);
 };
 
 export const isShapePointer = (board: PlaitBoard) => {
+  return isShapePointerType(board.pointer);
+};
+
+const isArrowLinePointerType = (pointer?: string) => {
+  return Object.values(ArrowLineShape).includes(pointer as ArrowLineShape);
+};
+
+const isShapePointerType = (pointer?: string) => {
   return (
-    Object.keys(BasicShapes).includes(board.pointer) ||
-    Object.keys(FlowchartSymbols).includes(board.pointer)
+    Object.values(BasicShapes).includes(pointer as BasicShapes) ||
+    Object.values(FlowchartSymbols).includes(pointer as FlowchartSymbols)
+  );
+};
+
+const isShapeMenuPointer = (pointer?: string) => {
+  return pointer !== BasicShapes.text && isShapePointerType(pointer);
+};
+
+const isFreehandPointer = (pointer?: string) => {
+  return (
+    pointer === FreehandShape.feltTipPen || pointer === FreehandShape.eraser
   );
 };
 
@@ -135,7 +153,7 @@ export const CreationToolbar = () => {
   const { appState, setAppState } = useDrawnix();
   const toolState = appState.toolState;
   const { t } = useI18n();
-  const container = PlaitBoard.getBoardContainer(board);
+  const container = PlaitBoard.getBoardContainer(board) ?? null;
 
   const [freehandOpen, setFreehandOpen] = useState(false);
   const [arrowOpen, setArrowOpen] = useState(false);
@@ -157,6 +175,33 @@ export const CreationToolbar = () => {
     }));
   };
 
+  useEffect(() => {
+    if (!container) {
+      return;
+    }
+    if (isFreehandPointer(toolState.pointer)) {
+      setFreehandOpen(true);
+      setArrowOpen(false);
+      setShapeOpen(false);
+      return;
+    }
+    if (isArrowLinePointerType(toolState.pointer)) {
+      setFreehandOpen(false);
+      setArrowOpen(true);
+      setShapeOpen(false);
+      return;
+    }
+    if (isShapeMenuPointer(toolState.pointer)) {
+      setFreehandOpen(false);
+      setArrowOpen(false);
+      setShapeOpen(true);
+      return;
+    }
+    setFreehandOpen(false);
+    setArrowOpen(false);
+    setShapeOpen(false);
+  }, [container, toolState.pointer]);
+
   const onPointerDown = (pointer: DrawnixPointerType) => {
     setCreationMode(board, BoardCreationMode.dnd);
     BoardTransforms.updatePointerType(board, pointer);
@@ -174,10 +219,7 @@ export const CreationToolbar = () => {
   };
 
   const checkCurrentPointerIsFreehand = (board: PlaitBoard) => {
-    return PlaitBoard.isInPointer(board, [
-      FreehandShape.feltTipPen,
-      FreehandShape.eraser,
-    ]);
+    return isFreehandPointer(board.pointer);
   };
 
   const updateFreehandSettings = (
@@ -245,7 +287,7 @@ export const CreationToolbar = () => {
                     }}
                   />
                 </PopoverTrigger>
-                <PopoverContent container={container}>
+                <PopoverContent container={container} initialFocus={-1}>
                   <FreehandPanel
                     freehandPresets={toolState.freehandPresets}
                     activePresetIndex={toolState.activeFreehandPresetIndex}
@@ -320,7 +362,7 @@ export const CreationToolbar = () => {
                     }}
                   />
                 </PopoverTrigger>
-                <PopoverContent container={container}>
+                <PopoverContent container={container} initialFocus={-1}>
                   <ShapePicker
                     onPointerUp={(pointer: DrawPointerType) => {
                       setShapeOpen(false);
@@ -369,7 +411,7 @@ export const CreationToolbar = () => {
                     }}
                   />
                 </PopoverTrigger>
-                <PopoverContent container={container}>
+                <PopoverContent container={container} initialFocus={-1}>
                   <ArrowPicker
                     onPointerUp={(pointer: DrawPointerType) => {
                       setArrowOpen(false);

--- a/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
@@ -35,9 +35,10 @@ import { useState } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '../popover/popover';
 import { FreehandShape } from '../../plugins/freehand/type';
 import {
+  DrawnixFreehandPointer,
   DrawnixPointerType,
+  DrawnixToolState,
   useDrawnix,
-  useSetPointer,
 } from '../../hooks/use-drawnix';
 import { ExtraToolsButton } from './extra-tools/extra-tools-button';
 import { addImage } from '../../utils/image';
@@ -132,28 +133,34 @@ export const isShapePointer = (board: PlaitBoard) => {
 export const CreationToolbar = () => {
   const board = useBoard();
   const { appState, setAppState } = useDrawnix();
+  const toolState = appState.toolState;
   const { t } = useI18n();
-  const setPointer = useSetPointer();
   const container = PlaitBoard.getBoardContainer(board);
 
   const [freehandOpen, setFreehandOpen] = useState(false);
   const [arrowOpen, setArrowOpen] = useState(false);
   const [shapeOpen, setShapeOpen] = useState(false);
-  const [lastFreehandButton, setLastFreehandButton] =
-    useState<AppToolButtonProps>(
-      BUTTONS.find((button) => button.key === PopupKey.freehand) || BUTTONS[4]
-    );
-  const [lastShapePointer, setLastShapePointer] = useState<
-    DrawPointerType | undefined
-  >(SHAPES[0].pointer);
-  const [lastArrowPointer, setLastArrowPointer] = useState<
-    DrawPointerType | undefined
-  >(ARROWS[0].pointer);
+  const lastFreehandButton: AppToolButtonProps =
+    FREEHANDS.find(
+      (freehand) => freehand.pointer === toolState.lastFreehandPointer
+    ) ||
+    BUTTONS.find((button) => button.key === PopupKey.freehand) ||
+    BUTTONS[4];
+
+  const updateToolState = (nextToolState: Partial<DrawnixToolState>) => {
+    setAppState((currentAppState) => ({
+      ...currentAppState,
+      toolState: {
+        ...currentAppState.toolState,
+        ...nextToolState,
+      },
+    }));
+  };
 
   const onPointerDown = (pointer: DrawnixPointerType) => {
     setCreationMode(board, BoardCreationMode.dnd);
     BoardTransforms.updatePointerType(board, pointer);
-    setPointer(pointer);
+    updateToolState({ pointer });
   };
 
   const onPointerUp = () => {
@@ -175,19 +182,24 @@ export const CreationToolbar = () => {
 
   const updateFreehandSettings = (
     presetIndex: number,
-    nextSettings: Partial<(typeof appState)['freehandPresets'][number]>
+    nextSettings: Partial<(typeof toolState)['freehandPresets'][number]>
   ) => {
     setAppState((currentAppState) => ({
       ...currentAppState,
-      freehandPresets: currentAppState.freehandPresets.map((preset, index) => {
-        if (index !== presetIndex) {
-          return preset;
-        }
-        return {
-          ...preset,
-          ...nextSettings,
-        };
-      }),
+      toolState: {
+        ...currentAppState.toolState,
+        freehandPresets: currentAppState.toolState.freehandPresets.map(
+          (preset, index) => {
+            if (index !== presetIndex) {
+              return preset;
+            }
+            return {
+              ...preset,
+              ...nextSettings,
+            };
+          }
+        ),
+      },
     }));
   };
 
@@ -235,13 +247,12 @@ export const CreationToolbar = () => {
                 </PopoverTrigger>
                 <PopoverContent container={container}>
                   <FreehandPanel
-                    freehandPresets={appState.freehandPresets}
-                    activePresetIndex={appState.activeFreehandPresetIndex}
+                    freehandPresets={toolState.freehandPresets}
+                    activePresetIndex={toolState.activeFreehandPresetIndex}
                     onPresetSelect={(presetIndex: number) => {
-                      setAppState((currentAppState) => ({
-                        ...currentAppState,
+                      updateToolState({
                         activeFreehandPresetIndex: presetIndex,
-                      }));
+                      });
                     }}
                     onStrokeColorSelect={(
                       presetIndex: number,
@@ -260,13 +271,10 @@ export const CreationToolbar = () => {
                       });
                     }}
                     onPointerUp={(pointer: DrawnixPointerType) => {
-                      setPointer(pointer);
-                      const selectedButton = FREEHANDS.find(
-                        (item) => item.pointer === pointer
-                      );
-                      if (selectedButton) {
-                        setLastFreehandButton(selectedButton);
-                      }
+                      updateToolState({
+                        pointer,
+                        lastFreehandPointer: pointer as DrawnixFreehandPointer,
+                      });
                     }}
                   ></FreehandPanel>
                 </PopoverContent>
@@ -300,11 +308,13 @@ export const CreationToolbar = () => {
                       if (isShapePointer(board)) {
                         BoardTransforms.updatePointerType(board, board.pointer);
                       } else {
-                        setPointer(lastShapePointer || SHAPES[0].pointer);
+                        updateToolState({
+                          pointer: toolState.lastShapePointer,
+                        });
                         setCreationMode(board, BoardCreationMode.drawing);
                         BoardTransforms.updatePointerType(
                           board,
-                          lastShapePointer || SHAPES[0].pointer
+                          toolState.lastShapePointer
                         );
                       }
                     }}
@@ -314,8 +324,10 @@ export const CreationToolbar = () => {
                   <ShapePicker
                     onPointerUp={(pointer: DrawPointerType) => {
                       setShapeOpen(false);
-                      setPointer(pointer);
-                      setLastShapePointer(pointer);
+                      updateToolState({
+                        pointer,
+                        lastShapePointer: pointer,
+                      });
                     }}
                   ></ShapePicker>
                 </PopoverContent>
@@ -348,9 +360,11 @@ export const CreationToolbar = () => {
                         setCreationMode(board, BoardCreationMode.drawing);
                         BoardTransforms.updatePointerType(
                           board,
-                          lastArrowPointer || ARROWS[0].pointer
+                          toolState.lastArrowPointer
                         );
-                        setPointer(lastArrowPointer || ARROWS[0].pointer);
+                        updateToolState({
+                          pointer: toolState.lastArrowPointer,
+                        });
                       }
                     }}
                   />
@@ -359,8 +373,10 @@ export const CreationToolbar = () => {
                   <ArrowPicker
                     onPointerUp={(pointer: DrawPointerType) => {
                       setArrowOpen(false);
-                      setPointer(pointer);
-                      setLastArrowPointer(pointer);
+                      updateToolState({
+                        pointer,
+                        lastArrowPointer: pointer as ArrowLineShape,
+                      });
                     }}
                   ></ArrowPicker>
                 </PopoverContent>
@@ -388,7 +404,7 @@ export const CreationToolbar = () => {
                   onPointerUp();
                 } else if (button.pointer && isBasicPointer(button.pointer)) {
                   BoardTransforms.updatePointerType(board, button.pointer);
-                  setPointer(button.pointer);
+                  updateToolState({ pointer: button.pointer });
                 }
                 if (button.key === 'image') {
                   addImage(board);

--- a/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
@@ -138,6 +138,10 @@ const isShapePointerType = (pointer?: string) => {
   );
 };
 
+const isShapeMenuPointer = (pointer?: string) => {
+  return pointer !== BasicShapes.text && isShapePointerType(pointer);
+};
+
 const isFreehandPointer = (pointer?: string) => {
   return (
     pointer === FreehandShape.feltTipPen || pointer === FreehandShape.eraser
@@ -182,8 +186,12 @@ export const CreationToolbar = () => {
       return;
     }
     setFreehandOpen(false);
-    setArrowOpen(false);
-    setShapeOpen(false);
+    if (!isArrowLinePointerType(toolState.pointer)) {
+      setArrowOpen(false);
+    }
+    if (!isShapeMenuPointer(toolState.pointer)) {
+      setShapeOpen(false);
+    }
   }, [container, toolState.pointer]);
 
   const onPointerDown = (pointer: DrawnixPointerType) => {

--- a/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
@@ -217,7 +217,7 @@ export const CreationToolbar = () => {
             return (
               <Popover
                 key={index}
-                open={freehandOpen || checkCurrentPointerIsFreehand(board)}
+                open={freehandOpen}
                 sideOffset={12}
                 onOpenChange={(open) => {
                   setFreehandOpen(open);

--- a/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
@@ -138,10 +138,6 @@ const isShapePointerType = (pointer?: string) => {
   );
 };
 
-const isShapeMenuPointer = (pointer?: string) => {
-  return pointer !== BasicShapes.text && isShapePointerType(pointer);
-};
-
 const isFreehandPointer = (pointer?: string) => {
   return (
     pointer === FreehandShape.feltTipPen || pointer === FreehandShape.eraser
@@ -183,18 +179,6 @@ export const CreationToolbar = () => {
       setFreehandOpen(true);
       setArrowOpen(false);
       setShapeOpen(false);
-      return;
-    }
-    if (isArrowLinePointerType(toolState.pointer)) {
-      setFreehandOpen(false);
-      setArrowOpen(true);
-      setShapeOpen(false);
-      return;
-    }
-    if (isShapeMenuPointer(toolState.pointer)) {
-      setFreehandOpen(false);
-      setArrowOpen(false);
-      setShapeOpen(true);
       return;
     }
     setFreehandOpen(false);
@@ -259,7 +243,7 @@ export const CreationToolbar = () => {
             return (
               <Popover
                 key={index}
-                open={freehandOpen}
+                open={freehandOpen || checkCurrentPointerIsFreehand(board)}
                 sideOffset={12}
                 onOpenChange={(open) => {
                   setFreehandOpen(open);

--- a/packages/drawnix/src/drawnix.tsx
+++ b/packages/drawnix/src/drawnix.tsx
@@ -177,11 +177,7 @@ export const Drawnix: React.FC<DrawnixProps> = ({
                 afterInit && afterInit(board);
               }}
             >
-              {tutorial &&
-                board &&
-                PlaitBoard.isPointer(board, PlaitPointerType.selection) && (
-                  <Tutorial />
-                )}
+              {tutorial && board && <Tutorial />}
             </Board>
             <AppToolbar></AppToolbar>
             <CreationToolbar></CreationToolbar>

--- a/packages/drawnix/src/drawnix.tsx
+++ b/packages/drawnix/src/drawnix.tsx
@@ -6,12 +6,13 @@ import {
   PlaitPlugin,
   PlaitPointerType,
   PlaitTheme,
+  BoardTransforms,
   Selection,
   ThemeColorMode,
   Viewport,
 } from '@plait/core';
-import React, { useState, useRef } from 'react';
-import { withGroup } from '@plait/common';
+import React, { useState, useRef, useEffect } from 'react';
+import { BoardCreationMode, setCreationMode, withGroup } from '@plait/common';
 import { withDraw } from '@plait/draw';
 import { MindThemeColors, withMind } from '@plait/mind';
 import MobileDetect from 'mobile-detect';
@@ -31,6 +32,8 @@ import {
   DrawnixBoard,
   DrawnixContext,
   DrawnixState,
+  DrawnixToolState,
+  mergeToolState,
 } from './hooks/use-drawnix';
 import { ClosePencilToolbar } from './components/toolbar/pencil-mode-toolbar';
 import { TTDDialog } from './components/ttd-dialog/ttd-dialog';
@@ -40,30 +43,48 @@ import { LinkPopup } from './components/popup/link-popup/link-popup';
 import { I18nProvider } from './i18n';
 import { Tutorial } from './components/tutorial';
 import { LASER_POINTER_CLASS_NAME } from './utils/laser-pointer';
-import { DEFAULT_FREEHAND_PRESETS } from './plugins/freehand/presets';
 
 export type DrawnixProps = {
   value: PlaitElement[];
   viewport?: Viewport;
   theme?: PlaitTheme;
+  initialToolState?: Partial<DrawnixToolState>;
   onChange?: (value: BoardChangeData) => void;
   onSelectionChange?: (selection: Selection | null) => void;
   onValueChange?: (value: PlaitElement[]) => void;
   onViewportChange?: (value: Viewport) => void;
   onThemeChange?: (value: ThemeColorMode) => void;
+  onToolStateChange?: (toolState: DrawnixToolState) => void;
   afterInit?: (board: PlaitBoard) => void;
   tutorial?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>;
+
+export type { DrawnixToolState } from './hooks/use-drawnix';
+
+const applyToolStateToBoard = (
+  board: PlaitBoard,
+  toolState: DrawnixToolState
+) => {
+  BoardTransforms.updatePointerType(board, toolState.pointer);
+  if (
+    toolState.pointer !== PlaitPointerType.hand &&
+    toolState.pointer !== PlaitPointerType.selection
+  ) {
+    setCreationMode(board, BoardCreationMode.drawing);
+  }
+};
 
 export const Drawnix: React.FC<DrawnixProps> = ({
   value,
   viewport,
   theme,
+  initialToolState,
   onChange,
   onSelectionChange,
   onViewportChange,
   onThemeChange,
   onValueChange,
+  onToolStateChange,
   afterInit,
   tutorial = false,
 }) => {
@@ -75,16 +96,11 @@ export const Drawnix: React.FC<DrawnixProps> = ({
   };
 
   const [appState, setAppState] = useState<DrawnixState>(() => {
-    // TODO: need to consider how to maintenance the pointer state in future
     const md = new MobileDetect(window.navigator.userAgent);
     return {
-      pointer: PlaitPointerType.hand,
+      toolState: mergeToolState(initialToolState),
       isMobile: md.mobile() !== null,
       isPencilMode: false,
-      freehandPresets: DEFAULT_FREEHAND_PRESETS.map((preset) => ({
-        ...preset,
-      })),
-      activeFreehandPresetIndex: 0,
       fileHandle: null,
       openDialogType: null,
       openCleanConfirm: false,
@@ -96,6 +112,18 @@ export const Drawnix: React.FC<DrawnixProps> = ({
   if (board) {
     board.appState = appState;
   }
+
+  const hasMountedToolStateRef = useRef(false);
+  const onToolStateChangeRef = useRef(onToolStateChange);
+  onToolStateChangeRef.current = onToolStateChange;
+
+  useEffect(() => {
+    if (!hasMountedToolStateRef.current) {
+      hasMountedToolStateRef.current = true;
+      return;
+    }
+    onToolStateChangeRef.current?.(appState.toolState);
+  }, [appState.toolState]);
 
   const updateAppState = (newAppState: Partial<DrawnixState>) => {
     setAppState((currentAppState) => ({
@@ -143,7 +171,9 @@ export const Drawnix: React.FC<DrawnixProps> = ({
           >
             <Board
               afterInit={(board) => {
-                setBoard(board as DrawnixBoard);
+                const drawnixBoard = board as DrawnixBoard;
+                applyToolStateToBoard(drawnixBoard, appState.toolState);
+                setBoard(drawnixBoard);
                 afterInit && afterInit(board);
               }}
             >

--- a/packages/drawnix/src/hooks/use-drawnix.spec.ts
+++ b/packages/drawnix/src/hooks/use-drawnix.spec.ts
@@ -1,3 +1,8 @@
+import { PlaitPointerType } from '@plait/core';
+import { ArrowLineShape, BasicShapes } from '@plait/draw';
+import { FreehandShape } from '../plugins/freehand/type';
+import { createDefaultToolState, mergeToolState } from './use-drawnix';
+
 jest.mock('@plait/core', () => ({
   DEFAULT_COLOR: '#000000',
   PlaitPointerType: {
@@ -29,11 +34,6 @@ jest.mock('@plait/mind', () => ({
     mind: 'mind',
   },
 }));
-
-import { PlaitPointerType } from '@plait/core';
-import { ArrowLineShape, BasicShapes } from '@plait/draw';
-import { FreehandShape } from '../plugins/freehand/type';
-import { createDefaultToolState, mergeToolState } from './use-drawnix';
 
 describe('drawnix tool state', () => {
   it('creates the default persistent tool state', () => {

--- a/packages/drawnix/src/hooks/use-drawnix.spec.ts
+++ b/packages/drawnix/src/hooks/use-drawnix.spec.ts
@@ -1,0 +1,65 @@
+jest.mock('@plait/core', () => ({
+  DEFAULT_COLOR: '#000000',
+  PlaitPointerType: {
+    hand: 'hand',
+    selection: 'selection',
+  },
+  ThemeColorMode: {
+    default: 'default',
+    colorful: 'colorful',
+    soft: 'soft',
+    retro: 'retro',
+    dark: 'dark',
+    starry: 'starry',
+  },
+}));
+
+jest.mock('@plait/draw', () => ({
+  ArrowLineShape: {
+    straight: 'straight',
+  },
+  BasicShapes: {
+    rectangle: 'rectangle',
+    diamond: 'diamond',
+  },
+}));
+
+jest.mock('@plait/mind', () => ({
+  MindPointerType: {
+    mind: 'mind',
+  },
+}));
+
+import { PlaitPointerType } from '@plait/core';
+import { ArrowLineShape, BasicShapes } from '@plait/draw';
+import { FreehandShape } from '../plugins/freehand/type';
+import { createDefaultToolState, mergeToolState } from './use-drawnix';
+
+describe('drawnix tool state', () => {
+  it('creates the default persistent tool state', () => {
+    const toolState = createDefaultToolState();
+
+    expect(toolState.pointer).toBe(PlaitPointerType.hand);
+    expect(toolState.lastShapePointer).toBe(BasicShapes.rectangle);
+    expect(toolState.lastArrowPointer).toBe(ArrowLineShape.straight);
+    expect(toolState.lastFreehandPointer).toBe(FreehandShape.feltTipPen);
+    expect(toolState.activeFreehandPresetIndex).toBe(0);
+    expect(toolState.freehandPresets.length).toBeGreaterThan(0);
+  });
+
+  it('merges stored partial tool state with safe defaults', () => {
+    const storedPresets = [{ strokeColor: '#ff0000', strokeWidth: 8 }];
+
+    const toolState = mergeToolState({
+      pointer: BasicShapes.diamond,
+      freehandPresets: storedPresets,
+    });
+
+    expect(toolState.pointer).toBe(BasicShapes.diamond);
+    expect(toolState.lastShapePointer).toBe(BasicShapes.rectangle);
+    expect(toolState.lastArrowPointer).toBe(ArrowLineShape.straight);
+    expect(toolState.freehandPresets).toEqual(storedPresets);
+    expect(toolState.freehandPresets).not.toBe(storedPresets);
+    expect(toolState.freehandPresets[0]).not.toBe(storedPresets[0]);
+  });
+});

--- a/packages/drawnix/src/hooks/use-drawnix.spec.ts
+++ b/packages/drawnix/src/hooks/use-drawnix.spec.ts
@@ -1,9 +1,10 @@
 import { PlaitPointerType } from '@plait/core';
 import { ArrowLineShape, BasicShapes } from '@plait/draw';
+import { describe, expect, it, vi } from 'vitest';
 import { FreehandShape } from '../plugins/freehand/type';
 import { createDefaultToolState, mergeToolState } from './use-drawnix';
 
-jest.mock('@plait/core', () => ({
+vi.mock('@plait/core', () => ({
   DEFAULT_COLOR: '#000000',
   PlaitPointerType: {
     hand: 'hand',
@@ -19,7 +20,7 @@ jest.mock('@plait/core', () => ({
   },
 }));
 
-jest.mock('@plait/draw', () => ({
+vi.mock('@plait/draw', () => ({
   ArrowLineShape: {
     straight: 'straight',
   },
@@ -29,7 +30,7 @@ jest.mock('@plait/draw', () => ({
   },
 }));
 
-jest.mock('@plait/mind', () => ({
+vi.mock('@plait/mind', () => ({
   MindPointerType: {
     mind: 'mind',
   },

--- a/packages/drawnix/src/hooks/use-drawnix.tsx
+++ b/packages/drawnix/src/hooks/use-drawnix.tsx
@@ -10,11 +10,14 @@ import {
   type SetStateAction,
 } from 'react';
 import { MindPointerType } from '@plait/mind';
-import { DrawPointerType } from '@plait/draw';
+import { ArrowLineShape, BasicShapes, DrawPointerType } from '@plait/draw';
 import { FreehandShape } from '../plugins/freehand/type';
 import { Editor } from 'slate';
 import { LinkElement } from '@plait/common';
-import { FreehandDrawOptions } from '../plugins/freehand/presets';
+import {
+  DEFAULT_FREEHAND_PRESETS,
+  FreehandDrawOptions,
+} from '../plugins/freehand/presets';
 import { DrawnixFileHandle } from '../data/json';
 
 export enum DialogType {
@@ -27,6 +30,43 @@ export type DrawnixPointerType =
   | MindPointerType
   | DrawPointerType
   | FreehandShape;
+
+export type DrawnixFreehandPointer =
+  | FreehandShape.feltTipPen
+  | FreehandShape.eraser;
+
+export type DrawnixToolState = {
+  pointer: DrawnixPointerType;
+  lastShapePointer: DrawPointerType;
+  lastArrowPointer: ArrowLineShape;
+  lastFreehandPointer: DrawnixFreehandPointer;
+  activeFreehandPresetIndex: number;
+  freehandPresets: FreehandDrawOptions[];
+};
+
+export const createDefaultToolState = (): DrawnixToolState => ({
+  pointer: PlaitPointerType.hand,
+  lastShapePointer: BasicShapes.rectangle,
+  lastArrowPointer: ArrowLineShape.straight,
+  lastFreehandPointer: FreehandShape.feltTipPen,
+  activeFreehandPresetIndex: 0,
+  freehandPresets: DEFAULT_FREEHAND_PRESETS.map((preset) => ({ ...preset })),
+});
+
+export const mergeToolState = (
+  toolState?: Partial<DrawnixToolState>
+): DrawnixToolState => {
+  const defaultToolState = createDefaultToolState();
+  const freehandPresets = toolState?.freehandPresets?.length
+    ? toolState.freehandPresets
+    : defaultToolState.freehandPresets;
+
+  return {
+    ...defaultToolState,
+    ...toolState,
+    freehandPresets: freehandPresets.map((preset) => ({ ...preset })),
+  };
+};
 
 export interface DrawnixBoard extends PlaitBoard {
   appState: DrawnixState;
@@ -42,11 +82,9 @@ export type LinkState = {
 };
 
 export type DrawnixState = {
-  pointer: DrawnixPointerType;
+  toolState: DrawnixToolState;
   isMobile: boolean;
   isPencilMode: boolean;
-  freehandPresets: FreehandDrawOptions[];
-  activeFreehandPresetIndex: number;
   fileHandle: DrawnixFileHandle;
   openDialogType: DialogType | null;
   openCleanConfirm: boolean;
@@ -76,6 +114,12 @@ export const useDrawnix = (): {
 export const useSetPointer = () => {
   const { setAppState } = useDrawnix();
   return (pointer: DrawnixPointerType) => {
-    setAppState((appState) => ({ ...appState, pointer }));
+    setAppState((appState) => ({
+      ...appState,
+      toolState: {
+        ...appState.toolState,
+        pointer,
+      },
+    }));
   };
 };

--- a/packages/drawnix/src/plugins/freehand/utils.ts
+++ b/packages/drawnix/src/plugins/freehand/utils.ts
@@ -25,8 +25,10 @@ import {
 } from '@plait/draw';
 
 type FreehandAppState = {
-  activeFreehandPresetIndex?: number;
-  freehandPresets?: FreehandDrawOptions[];
+  toolState?: {
+    activeFreehandPresetIndex?: number;
+    freehandPresets?: FreehandDrawOptions[];
+  };
 };
 
 export function getFreehandPointers() {
@@ -36,9 +38,9 @@ export function getFreehandPointers() {
 export const getFreehandDrawOptions = (board: PlaitBoard) => {
   const appState = (board as PlaitBoard & { appState?: FreehandAppState })
     .appState;
-  const activePresetIndex = appState?.activeFreehandPresetIndex || 0;
+  const activePresetIndex = appState?.toolState?.activeFreehandPresetIndex || 0;
   const activePreset =
-    appState?.freehandPresets?.[activePresetIndex] ||
+    appState?.toolState?.freehandPresets?.[activePresetIndex] ||
     DEFAULT_FREEHAND_PRESETS[activePresetIndex] ||
     DEFAULT_FREEHAND_PRESETS[0];
 

--- a/packages/drawnix/src/plugins/with-hotkey.ts
+++ b/packages/drawnix/src/plugins/with-hotkey.ts
@@ -7,7 +7,13 @@ import {
 import { isHotkey } from 'is-hotkey';
 import { addImage, saveAsImage } from '../utils/image';
 import { saveAsJSON, saveJSON } from '../data/json';
-import { DrawnixBoard, DrawnixState } from '../hooks/use-drawnix';
+import {
+  DrawnixBoard,
+  DrawnixFreehandPointer,
+  DrawnixPointerType,
+  DrawnixState,
+  DrawnixToolState,
+} from '../hooks/use-drawnix';
 import { BoardCreationMode, setCreationMode } from '@plait/common';
 import { MindPointerType } from '@plait/mind';
 import { FreehandShape } from './freehand/type';
@@ -18,6 +24,18 @@ export const buildDrawnixHotkeyPlugin = (
 ) => {
   const withDrawnixHotkey = (board: PlaitBoard) => {
     const { globalKeyDown, keyDown } = board;
+    const updatePointer = (
+      pointer: DrawnixPointerType,
+      nextToolState: Partial<DrawnixToolState> = {}
+    ) => {
+      updateAppState({
+        toolState: {
+          ...(board as DrawnixBoard).appState.toolState,
+          pointer,
+          ...nextToolState,
+        },
+      });
+    };
     board.globalKeyDown = (event: KeyboardEvent) => {
       const isTypingNormal =
         event.target instanceof HTMLInputElement ||
@@ -67,7 +85,7 @@ export const buildDrawnixHotkeyPlugin = (
         if (!event.altKey && !event.metaKey && !event.ctrlKey) {
           if (event.key === 'h') {
             BoardTransforms.updatePointerType(board, PlaitPointerType.hand);
-            updateAppState({ pointer: PlaitPointerType.hand });
+            updatePointer(PlaitPointerType.hand);
             event.preventDefault();
             return;
           }
@@ -76,28 +94,34 @@ export const buildDrawnixHotkeyPlugin = (
               board,
               PlaitPointerType.selection
             );
-            updateAppState({ pointer: PlaitPointerType.selection });
+            updatePointer(PlaitPointerType.selection);
             event.preventDefault();
             return;
           }
           if (event.key === 'm') {
             setCreationMode(board, BoardCreationMode.dnd);
             BoardTransforms.updatePointerType(board, MindPointerType.mind);
-            updateAppState({ pointer: MindPointerType.mind });
+            updatePointer(MindPointerType.mind);
             event.preventDefault();
             return;
           }
           if (event.key === 'e') {
             setCreationMode(board, BoardCreationMode.drawing);
             BoardTransforms.updatePointerType(board, FreehandShape.eraser);
-            updateAppState({ pointer: FreehandShape.eraser });
+            updatePointer(FreehandShape.eraser, {
+              lastFreehandPointer:
+                FreehandShape.eraser as DrawnixFreehandPointer,
+            });
             event.preventDefault();
             return;
           }
           if (event.key === 'p') {
             setCreationMode(board, BoardCreationMode.drawing);
             BoardTransforms.updatePointerType(board, FreehandShape.feltTipPen);
-            updateAppState({ pointer: FreehandShape.feltTipPen });
+            updatePointer(FreehandShape.feltTipPen, {
+              lastFreehandPointer:
+                FreehandShape.feltTipPen as DrawnixFreehandPointer,
+            });
             event.preventDefault();
             return;
           }
@@ -106,7 +130,9 @@ export const buildDrawnixHotkeyPlugin = (
             if (getSelectedElements(board).length === 0) {
               setCreationMode(board, BoardCreationMode.drawing);
               BoardTransforms.updatePointerType(board, ArrowLineShape.straight);
-              updateAppState({ pointer: ArrowLineShape.straight });
+              updatePointer(ArrowLineShape.straight, {
+                lastArrowPointer: ArrowLineShape.straight,
+              });
               event.preventDefault();
               return;
             }
@@ -123,7 +149,11 @@ export const buildDrawnixHotkeyPlugin = (
               setCreationMode(board, BoardCreationMode.drawing);
             }
             BoardTransforms.updatePointerType(board, keyToPointer[event.key]);
-            updateAppState({ pointer: keyToPointer[event.key] });
+            updatePointer(keyToPointer[event.key], {
+              ...(keyToPointer[event.key] === BasicShapes.text
+                ? {}
+                : { lastShapePointer: keyToPointer[event.key] }),
+            });
             event.preventDefault();
             return;
           }


### PR DESCRIPTION
## Summary

This PR addresses #414 by persisting the Web/PWA tool selection experience across reloads, instead of only restoring the board content.

What changed:

- Added a serializable `DrawnixToolState` for tool-related state:
  - current `pointer`
  - last selected shape tool
  - last selected arrow tool
  - last selected freehand tool
  - active freehand preset index
  - freehand preset settings
- Added `initialToolState` and `onToolStateChange` to `Drawnix`, so the library exposes state initialization/change hooks while keeping storage owned by the app layer.
- Persisted tool state in the Web app with a separate `localforage` key: `main_board_tool_state`.
- Moved toolbar-owned last-tool state into `appState.toolState`, so toolbar clicks and hotkeys both update the same persistent state.
- Restored the board pointer during initialization so the recovered tool is immediately active.
- Kept transient UI state out of persistence: popovers, dialogs, selection, link editing/hover state, and file handles are not restored.

## UX decisions and questions

The current implementation restores the specific selected tool, but does **not** automatically open the secondary/detail menu after reload.

For example, if the user reloads after selecting the pen or eraser, the tool is restored and active, but the freehand detail panel stays collapsed. This matches the usual behavior after selecting a tool: the detail panel is temporary UI and normally closes once the user starts working.

Question 1: do we want to keep this collapsed-on-restore behavior, or should restoring a tool also open its detail panel so users can immediately see details like freehand color and stroke width?

There is also one existing semantic inconsistency in the toolbar:

- Freehand currently changes the top-level toolbar icon between pen and eraser based on the selected sub-tool.
- Shape/arrow currently restore the exact sub-tool internally, but the top-level toolbar icon remains generic.

Question 2: should we make shape/arrow behave like freehand, where choosing a specific shape/arrow also changes the top-level toolbar icon? If yes, I think we can track that as a separate small follow-up issue/PR.

## Verification

- `npx nx test drawnix`
- `npx nx build web`
- `git diff --check`

Known build output still includes existing Sass/package-export/chunk-size warnings; no new failing checks were introduced.