### PR TITLE
feat(popup-toolbar): modified tool icon size from 20px to 18px for popup toolbar

### DIFF
--- a/packages/drawnix/src/components/toolbar/popup-toolbar/popup-toolbar.scss
+++ b/packages/drawnix/src/components/toolbar/popup-toolbar/popup-toolbar.scss
@@ -83,12 +83,6 @@
             border-width: var(--border-radius-sm);
             border-style: solid;
         }
-        .tool-icon__icon {
-            svg {
-                width: var(--xlg-icon-size);
-                height: var(--xlg-icon-size);
-            }
-        }
     }
 }
 .stroke-setting {

--- a/packages/drawnix/src/styles/theme.scss
+++ b/packages/drawnix/src/styles/theme.scss
@@ -16,7 +16,7 @@
   --lg-button-size: 2.25rem;
   --lg-icon-size: 1.125rem;
   --xlg-icon-size: 1.25rem;
-  --popup-label-size: 1.25rem;
+  --popup-label-size: 1.125rem;
   --editor-container-padding: 1rem;
 
   @media screen and (min-device-width: 1921px) {


### PR DESCRIPTION
20px is too large and 18px is similar with creation toolbar icon
1. modify --popup-label-size from `1.25rem(20px)` to `1.125rem(18px)`, it effects fill and stroke
2. remove special style for `popup-toolbar property-button tool-icon__icon`, this class set svg's width and height as 20px, the original width and height are `--lg-icon-size(18px)`

before:
<img width="1173" height="455" alt="Screenshot 2026-06-14 at 13 44 40" src="https://github.com/user-attachments/assets/ad53130a-3ef5-4e72-b9c2-e625af42d666" />

After change:
<img width="1173" height="455" alt="Screenshot 2026-06-14 at 13 45 44" src="https://github.com/user-attachments/assets/4611a2c6-2624-412a-b856-2b05d812475b" />
