### PR TITLE
feat(menu): add ChevronRightIcon and apply it for menuitem with submenu

### DIFF
--- a/packages/drawnix/src/components/icons.tsx
+++ b/packages/drawnix/src/components/icons.tsx
@@ -546,6 +546,23 @@ export const ChevronDownIcon = createIcon(
   </svg>
 );
 
+export const ChevronRightIcon = createIcon(
+  <svg
+    width="15"
+    height="15"
+    viewBox="0 0 15 15"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M6.15803 11.8648C5.95657 11.6759 5.94637 11.3595 6.13523 11.158L9.56464 7.5L6.13523 3.84197C5.94637 3.64052 5.95657 3.3241 6.15803 3.13523C6.35949 2.94637 6.67591 2.95657 6.86477 3.15803L10.6148 7.15803C10.7951 7.35036 10.7951 7.64964 10.6148 7.84197L6.86477 11.842C6.67591 12.0434 6.35949 12.0536 6.15803 11.8648Z"
+      fill="currentColor"
+      fillRule="evenodd"
+      clipRule="evenodd"
+    ></path>
+  </svg>
+);
+
 export const ThickCheckIcon = createIcon(
   <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path

--- a/packages/drawnix/src/components/icons.tsx
+++ b/packages/drawnix/src/components/icons.tsx
@@ -547,13 +547,7 @@ export const ChevronDownIcon = createIcon(
 );
 
 export const ChevronRightIcon = createIcon(
-  <svg
-    width="15"
-    height="15"
-    viewBox="0 0 15 15"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
+  <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
       d="M6.15803 11.8648C5.95657 11.6759 5.94637 11.3595 6.13523 11.158L9.56464 7.5L6.13523 3.84197C5.94637 3.64052 5.95657 3.3241 6.15803 3.13523C6.35949 2.94637 6.67591 2.95657 6.86477 3.15803L10.6148 7.15803C10.7951 7.35036 10.7951 7.64964 10.6148 7.84197L6.86477 11.842C6.67591 12.0434 6.35949 12.0536 6.15803 11.8648Z"
       fill="currentColor"

--- a/packages/drawnix/src/components/menu/menu-item-content-switch.tsx
+++ b/packages/drawnix/src/components/menu/menu-item-content-switch.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { MenuItemSwitch } from './menu-item-switch';
+
+export type MenuItemContentSwitchProps = {
+  checked: boolean;
+  children: React.ReactNode;
+};
+
+const MenuItemContentSwitch = ({ checked, children }: MenuItemContentSwitchProps) => {
+  return (
+    <>
+      <div className="menu-item__left" aria-hidden="true">
+        <MenuItemSwitch checked={checked} />
+      </div>
+      <div className="menu-item__right">
+        <div className="menu-item__label">{children}</div>
+      </div>
+    </>
+  );
+};
+
+MenuItemContentSwitch.displayName = 'MenuItemContentSwitch';
+(MenuItemContentSwitch as any).__DRAWNIX_MENU_ITEM_CONTENT = true;
+
+export default MenuItemContentSwitch;

--- a/packages/drawnix/src/components/menu/menu-item-content.tsx
+++ b/packages/drawnix/src/components/menu/menu-item-content.tsx
@@ -19,11 +19,7 @@ const MenuItemContent = ({
       {(shortcut || hasSubmenu) && (
         <div className="menu-item__right">
           {shortcut && <div className="menu-item__shortcut">{shortcut}</div>}
-          {hasSubmenu && (
-            <div className="menu-item__submenu-indicator">
-              {ChevronRightIcon}
-            </div>
-          )}
+          {hasSubmenu && <div className="menu-item__submenu-indicator">{ChevronRightIcon}</div>}
         </div>
       )}
     </>

--- a/packages/drawnix/src/components/menu/menu-item-content.tsx
+++ b/packages/drawnix/src/components/menu/menu-item-content.tsx
@@ -1,6 +1,19 @@
 import React from 'react';
 import { ChevronRightIcon } from '../icons';
 
+export const MenuItemSwitch = ({ checked }: { checked: boolean }) => {
+  return (
+    <span
+      className={`menu-item-switch ${
+        checked ? 'menu-item-switch--checked' : ''
+      }`.trim()}
+      aria-hidden="true"
+    >
+      <span className="menu-item-switch__thumb" />
+    </span>
+  );
+};
+
 const MenuItemContent = ({
   icon,
   shortcut,

--- a/packages/drawnix/src/components/menu/menu-item-content.tsx
+++ b/packages/drawnix/src/components/menu/menu-item-content.tsx
@@ -1,36 +1,29 @@
 import React from 'react';
 import { ChevronRightIcon } from '../icons';
 
-export const MenuItemSwitch = ({ checked }: { checked: boolean }) => {
-  return (
-    <span
-      className={`menu-item-switch ${checked ? 'menu-item-switch--checked' : ''}`.trim()}
-      aria-hidden="true"
-    >
-      <span className="menu-item-switch__thumb" />
-    </span>
-  );
-};
-
 const MenuItemContent = ({
   icon,
   shortcut,
-  hasSubmenu,
   children,
+  hasSubmenu,
 }: {
   icon?: React.ReactNode;
   shortcut?: string;
-  hasSubmenu?: boolean;
   children: React.ReactNode;
+  hasSubmenu?: boolean;
 }) => {
   return (
     <>
-      {icon && <div className="menu-item__icon">{icon}</div>}
+      {icon && <div className="menu-item__left">{icon}</div>}
       <div className="menu-item__text">{children}</div>
       {(shortcut || hasSubmenu) && (
         <div className="menu-item__right">
           {shortcut && <div className="menu-item__shortcut">{shortcut}</div>}
-          {hasSubmenu && <div className="menu-item__submenu-indicator">{ChevronRightIcon}</div>}
+          {hasSubmenu && (
+            <div className="menu-item__submenu-indicator">
+              {ChevronRightIcon}
+            </div>
+          )}
         </div>
       )}
     </>

--- a/packages/drawnix/src/components/menu/menu-item-content.tsx
+++ b/packages/drawnix/src/components/menu/menu-item-content.tsx
@@ -1,19 +1,31 @@
 import React from 'react';
+import { ChevronRightIcon } from '../icons';
 
 const MenuItemContent = ({
   icon,
   shortcut,
+  hasSubmenu,
   children,
 }: {
   icon?: React.ReactNode;
   shortcut?: string;
+  hasSubmenu?: boolean;
   children: React.ReactNode;
 }) => {
   return (
     <>
       {icon && <div className="menu-item__icon">{icon}</div>}
       <div className="menu-item__text">{children}</div>
-      {shortcut && <div className="menu-item__shortcut">{shortcut}</div>}
+      {(shortcut || hasSubmenu) && (
+        <div className="menu-item__right">
+          {shortcut && <div className="menu-item__shortcut">{shortcut}</div>}
+          {hasSubmenu && (
+            <div className="menu-item__submenu-indicator">
+              {ChevronRightIcon}
+            </div>
+          )}
+        </div>
+      )}
     </>
   );
 };

--- a/packages/drawnix/src/components/menu/menu-item-content.tsx
+++ b/packages/drawnix/src/components/menu/menu-item-content.tsx
@@ -4,9 +4,7 @@ import { ChevronRightIcon } from '../icons';
 export const MenuItemSwitch = ({ checked }: { checked: boolean }) => {
   return (
     <span
-      className={`menu-item-switch ${
-        checked ? 'menu-item-switch--checked' : ''
-      }`.trim()}
+      className={`menu-item-switch ${checked ? 'menu-item-switch--checked' : ''}`.trim()}
       aria-hidden="true"
     >
       <span className="menu-item-switch__thumb" />
@@ -32,11 +30,7 @@ const MenuItemContent = ({
       {(shortcut || hasSubmenu) && (
         <div className="menu-item__right">
           {shortcut && <div className="menu-item__shortcut">{shortcut}</div>}
-          {hasSubmenu && (
-            <div className="menu-item__submenu-indicator">
-              {ChevronRightIcon}
-            </div>
-          )}
+          {hasSubmenu && <div className="menu-item__submenu-indicator">{ChevronRightIcon}</div>}
         </div>
       )}
     </>

--- a/packages/drawnix/src/components/menu/menu-item-switch.tsx
+++ b/packages/drawnix/src/components/menu/menu-item-switch.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export type MenuItemSwitchProps = {
+  checked: boolean;
+};
+
+export const MenuItemSwitch = ({ checked }: MenuItemSwitchProps) => {
+  return (
+    <span
+      className={`menu-item-switch ${
+        checked ? 'menu-item-switch--checked' : ''
+      }`.trim()}
+      aria-hidden="true"
+    >
+      <span className="menu-item-switch__thumb" />
+    </span>
+  );
+};
+
+MenuItemSwitch.displayName = 'MenuItemSwitch';
+

--- a/packages/drawnix/src/components/menu/menu-item-switch.tsx
+++ b/packages/drawnix/src/components/menu/menu-item-switch.tsx
@@ -7,9 +7,7 @@ export type MenuItemSwitchProps = {
 export const MenuItemSwitch = ({ checked }: MenuItemSwitchProps) => {
   return (
     <span
-      className={`menu-item-switch ${
-        checked ? 'menu-item-switch--checked' : ''
-      }`.trim()}
+      className={`menu-item-switch ${checked ? 'menu-item-switch--checked' : ''}`.trim()}
       aria-hidden="true"
     >
       <span className="menu-item-switch__thumb" />
@@ -18,4 +16,3 @@ export const MenuItemSwitch = ({ checked }: MenuItemSwitchProps) => {
 };
 
 MenuItemSwitch.displayName = 'MenuItemSwitch';
-

--- a/packages/drawnix/src/components/menu/menu-item.tsx
+++ b/packages/drawnix/src/components/menu/menu-item.tsx
@@ -3,6 +3,12 @@ import { getMenuItemClassName, useHandleMenuItemClick } from './common';
 import MenuItemContent from './menu-item-content';
 import { Popover, PopoverContent, PopoverTrigger } from '../popover/popover';
 
+const isMenuItemContentElement = (node: React.ReactNode) => {
+  return (
+    React.isValidElement(node) && (node.type as any)?.__DRAWNIX_MENU_ITEM_CONTENT === true
+  );
+};
+
 const MenuItem = ({
   icon,
   onSelect,
@@ -15,7 +21,7 @@ const MenuItem = ({
 }: {
   icon?: React.ReactNode;
   onSelect: (event: Event) => void;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   shortcut?: string;
   selected?: boolean;
   className?: string;
@@ -26,11 +32,14 @@ const MenuItem = ({
   const handleClick = useHandleMenuItemClick(rest.onClick, onSelect);
   const hasSubmenu = !!submenu;
 
-  const menuItemContent = (
-    <MenuItemContent icon={icon} shortcut={shortcut} hasSubmenu={hasSubmenu}>
-      {children}
-    </MenuItemContent>
-  );
+  const menuItemContent =
+    children && isMenuItemContentElement(children) ? (
+      children
+    ) : children ? (
+      <MenuItemContent icon={icon} shortcut={shortcut} hasSubmenu={hasSubmenu}>
+        {children}
+      </MenuItemContent>
+    ) : null;
 
   const handleMouseEnter = () => {
     if (closeTimeoutRef.current) {

--- a/packages/drawnix/src/components/menu/menu-item.tsx
+++ b/packages/drawnix/src/components/menu/menu-item.tsx
@@ -4,9 +4,7 @@ import MenuItemContent from './menu-item-content';
 import { Popover, PopoverContent, PopoverTrigger } from '../popover/popover';
 
 const isMenuItemContentElement = (node: React.ReactNode) => {
-  return (
-    React.isValidElement(node) && (node.type as any)?.__DRAWNIX_MENU_ITEM_CONTENT === true
-  );
+  return React.isValidElement(node) && (node.type as any)?.__DRAWNIX_MENU_ITEM_CONTENT === true;
 };
 
 const MenuItem = ({

--- a/packages/drawnix/src/components/menu/menu-item.tsx
+++ b/packages/drawnix/src/components/menu/menu-item.tsx
@@ -24,9 +24,10 @@ const MenuItem = ({
   const [isOpen, setIsOpen] = useState(false);
   const closeTimeoutRef = useRef<number>();
   const handleClick = useHandleMenuItemClick(rest.onClick, onSelect);
+  const hasSubmenu = !!submenu;
 
   const menuItemContent = (
-    <MenuItemContent icon={icon} shortcut={shortcut}>
+    <MenuItemContent icon={icon} shortcut={shortcut} hasSubmenu={hasSubmenu}>
       {children}
     </MenuItemContent>
   );

--- a/packages/drawnix/src/components/menu/menu.scss
+++ b/packages/drawnix/src/components/menu/menu.scss
@@ -23,7 +23,7 @@
 
     .menu-container {
       background-color: var(--island-bg-color);
-      min-width: 200px;
+      min-width: 160px;
       max-height: calc(100vh - 150px);
       overflow-y: auto;
       --gap: 2;
@@ -57,6 +57,16 @@
       &--active {
         background-color: var(--color-surface-primary-container);
         text-decoration: none;
+      }
+
+      &--setting {
+        margin-top: 0.5rem;
+        background-color: var(--color-surface-low);
+      }
+
+      &__icon {
+        display: flex;
+        align-items: center;
       }
 
       &__text {
@@ -93,14 +103,57 @@
         opacity: 0.5;
       }
 
+      .menu-item-switch {
+        width: 24px;
+        height: 14px;
+        border-radius: 9999px;
+        box-sizing: border-box;
+        display: inline-flex;
+        align-items: center;
+        padding: 2px;
+        border: 1px solid var(--color-gray-30);
+        background-color: var(--color-gray-20);
+        transition: background-color 120ms ease, border-color 120ms ease;
+        line-height: 0;
+
+        &__thumb {
+          width: 9px;
+          height: 9px;
+          border-radius: 9999px;
+          background-color: var(--color-gray-60);
+          transform: translateX(0);
+          transition: transform 120ms ease, background-color 120ms ease;
+        }
+
+        &--checked {
+          background-color: var(--color-surface-lowest);
+          border-color: currentColor;
+          opacity: 0.8;
+
+          .menu-item-switch__thumb {
+            transform: translateX(9px);
+            background-color: currentColor;
+          }
+        }
+      }
+
       &:hover {
         background-color: var(--color-surface-primary-container);
         text-decoration: none;
       }
 
+      &--setting:hover {
+        background-color: var(--color-surface-low);
+      }
+
       &:active {
         background-color: var(--color-surface-primary-container);
         border-color: var(--color-brand-active);
+      }
+
+      &--setting:active {
+        background-color: var(--color-surface-low);
+        border-color: transparent;
       }
 
       svg {

--- a/packages/drawnix/src/components/menu/menu.scss
+++ b/packages/drawnix/src/components/menu/menu.scss
@@ -64,7 +64,7 @@
         background-color: var(--color-surface-low);
       }
 
-      &__icon {
+      &__left {
         display: flex;
         align-items: center;
       }
@@ -77,6 +77,15 @@
         overflow: hidden;
         white-space: nowrap;
         gap: 0.75rem;
+      }
+
+      &__label {
+        font-size: 0.75rem;
+        opacity: 0.5;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        text-align: right;
       }
 
       &__shortcut {

--- a/packages/drawnix/src/components/menu/menu.scss
+++ b/packages/drawnix/src/components/menu/menu.scss
@@ -23,6 +23,7 @@
 
     .menu-container {
       background-color: var(--island-bg-color);
+      min-width: 200px;
       max-height: calc(100vh - 150px);
       overflow-y: auto;
       --gap: 2;
@@ -69,14 +70,27 @@
       }
 
       &__shortcut {
-        margin-inline-start: auto;
+        font-size: 0.75rem;
         opacity: 0.5;
 
         &--orphaned {
           text-align: right;
-          font-size: 0.875rem;
+          font-size: 0.75rem;
           padding: 0 0.625rem;
         }
+      }
+
+      &__right {
+        margin-inline-start: auto;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        min-width: 56px;
+        justify-content: flex-end;
+      }
+
+      &__submenu-indicator {
+        opacity: 0.5;
       }
 
       &:hover {

--- a/packages/drawnix/src/components/menu/menu.tsx
+++ b/packages/drawnix/src/components/menu/menu.tsx
@@ -9,6 +9,7 @@ const Menu = ({
   className = '',
   onSelect,
   style,
+  containerStyle,
 }: {
   children?: React.ReactNode;
   className?: string;
@@ -17,6 +18,7 @@ const Menu = ({
    */
   onSelect?: (event: Event) => void;
   style?: React.CSSProperties;
+  containerStyle?: React.CSSProperties;
 }) => {
   const newClassName = classNames(`menu ${className}`).trim();
 
@@ -24,7 +26,7 @@ const Menu = ({
     <MenuContentPropsContext.Provider value={{ onSelect }}>
       <div className={newClassName} style={style} data-testid="menu">
         {
-          <Island className="menu-container" padding={2}>
+          <Island className="menu-container" padding={2} style={containerStyle}>
             {children}
           </Island>
         }

--- a/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
+++ b/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
@@ -139,6 +139,7 @@ export const SaveAsImage = () => {
               saveAsImage(board, true);
             }}
             aria-label={t('menu.exportImage.png')}
+            shortcut={getShortcutKey('CtrlOrCmd+Shift+E')}
           >
             {t('menu.exportImage.png')}
           </MenuItem>
@@ -152,7 +153,6 @@ export const SaveAsImage = () => {
           </MenuItem>
         </Menu>
       }
-      shortcut={getShortcutKey('CtrlOrCmd+Shift+E')}
       aria-label={t('menu.exportImage')}
     >
       {t('menu.exportImage')}

--- a/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
+++ b/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
@@ -115,7 +115,7 @@ export const SaveAsImage = () => {
     <MenuItem
       icon={ExportImageIcon}
       data-testid="image-export-button"
-      onSelect={() => {}}
+      onSelect={() => undefined}
       submenu={
         <Menu
           onSelect={() => {

--- a/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
+++ b/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
@@ -4,7 +4,7 @@ import { BoardTransforms, PlaitBoard, PlaitElement, PlaitTheme, Viewport } from 
 import { loadFromJSON, saveAsJSON, saveJSON } from '../../../data/json';
 import MenuItem from '../../menu/menu-item';
 import MenuItemLink from '../../menu/menu-item-link';
-import { saveAsImage, saveAsSvg } from '../../../utils/image';
+import { saveAsPng, saveAsSvg } from '../../../utils/image';
 import { useDrawnix } from '../../../hooks/use-drawnix';
 import { useI18n } from '../../../i18n';
 import Menu from '../../menu/menu';
@@ -12,6 +12,7 @@ import { useContext } from 'react';
 import { MenuContentPropsContext } from '../../menu/common';
 import { EVENT } from '../../../constants';
 import { getShortcutKey } from '../../../utils/common';
+import { MenuItemSwitch } from '../../menu/menu-item-content';
 
 export const SaveToFile = () => {
   const board = useBoard();
@@ -107,15 +108,14 @@ OpenFile.displayName = 'OpenFile';
 
 export const SaveAsImage = () => {
   const board = useBoard();
+  const { appState, setAppState } = useDrawnix();
   const menuContentProps = useContext(MenuContentPropsContext);
   const { t } = useI18n();
   return (
     <MenuItem
       icon={ExportImageIcon}
       data-testid="image-export-button"
-      onSelect={() => {
-        saveAsImage(board, true);
-      }}
+      onSelect={() => {}}
       submenu={
         <Menu
           onSelect={() => {
@@ -131,25 +131,32 @@ export const SaveAsImage = () => {
               saveAsSvg(board);
             }}
             aria-label={t('menu.exportImage.svg')}
+            shortcut={getShortcutKey('CtrlOrCmd+Shift+E')}
           >
             {t('menu.exportImage.svg')}
           </MenuItem>
           <MenuItem
             onSelect={() => {
-              saveAsImage(board, true);
+              saveAsPng(board);
             }}
             aria-label={t('menu.exportImage.png')}
-            shortcut={getShortcutKey('CtrlOrCmd+Shift+E')}
           >
             {t('menu.exportImage.png')}
           </MenuItem>
           <MenuItem
-            onSelect={() => {
-              saveAsImage(board, false);
+            onSelect={(event) => {
+              event.preventDefault();
+              setAppState((currentAppState) => ({
+                ...currentAppState,
+                exportTransparent: !currentAppState.exportTransparent,
+              }));
             }}
-            aria-label={t('menu.exportImage.jpg')}
+            className="menu-item--setting"
+            icon={<MenuItemSwitch checked={appState.exportTransparent} />}
+            shortcut={t('general.copyToClipboard.transparent')}
+            aria-label={t('general.copyToClipboard.transparent')}
           >
-            {t('menu.exportImage.jpg')}
+            {null}
           </MenuItem>
         </Menu>
       }

--- a/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
+++ b/packages/drawnix/src/components/toolbar/app-toolbar/app-menu-items.tsx
@@ -8,11 +8,11 @@ import { saveAsPng, saveAsSvg } from '../../../utils/image';
 import { useDrawnix } from '../../../hooks/use-drawnix';
 import { useI18n } from '../../../i18n';
 import Menu from '../../menu/menu';
+import MenuItemContentSwitch from '../../menu/menu-item-content-switch';
 import { useContext } from 'react';
 import { MenuContentPropsContext } from '../../menu/common';
 import { EVENT } from '../../../constants';
 import { getShortcutKey } from '../../../utils/common';
-import { MenuItemSwitch } from '../../menu/menu-item-content';
 
 export const SaveToFile = () => {
   const board = useBoard();
@@ -152,11 +152,13 @@ export const SaveAsImage = () => {
               }));
             }}
             className="menu-item--setting"
-            icon={<MenuItemSwitch checked={appState.exportTransparent} />}
-            shortcut={t('general.copyToClipboard.transparent')}
+            role="menuitemcheckbox"
+            aria-checked={appState.exportTransparent}
             aria-label={t('general.copyToClipboard.transparent')}
           >
-            {null}
+            <MenuItemContentSwitch checked={appState.exportTransparent}>
+              {t('general.copyToClipboard.transparent')}
+            </MenuItemContentSwitch>
           </MenuItem>
         </Menu>
       }

--- a/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
@@ -24,8 +24,8 @@ import { MindPointerType } from '@plait/mind';
 import { BoardCreationMode, setCreationMode } from '@plait/common';
 import { ArrowLineShape, BasicShapes, DrawPointerType, FlowchartSymbols } from '@plait/draw';
 import { FreehandPanel } from './freehand-panel/freehand-panel';
-import { ShapePicker } from '../shape-picker';
-import { ArrowPicker } from '../arrow-picker';
+import { ShapePicker, SHAPES } from '../shape-picker';
+import { ArrowPicker, ARROWS } from '../arrow-picker';
 import { useEffect, useState } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '../popover/popover';
 import { FreehandShape } from '../../plugins/freehand/type';
@@ -157,12 +157,8 @@ export const CreationToolbar = () => {
   const currentArrowPointer = isArrowLinePointerType(toolState.pointer)
     ? toolState.pointer
     : toolState.lastArrowPointer;
-  const lastShapeButton = SHAPES.find(
-    (shape) => shape.pointer === currentShapePointer
-  );
-  const lastArrowButton = ARROWS.find(
-    (arrow) => arrow.pointer === currentArrowPointer
-  );
+  const lastShapeButton = SHAPES.find((shape) => shape.pointer === currentShapePointer);
+  const lastArrowButton = ARROWS.find((arrow) => arrow.pointer === currentArrowPointer);
 
   const updateToolState = (nextToolState: Partial<DrawnixToolState>) => {
     setAppState((currentAppState) => ({

--- a/packages/drawnix/src/components/toolbar/popup-toolbar/more-options-button.tsx
+++ b/packages/drawnix/src/components/toolbar/popup-toolbar/more-options-button.tsx
@@ -73,7 +73,6 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({ board }) =
           </MenuItem>
           <MenuItem
             onSelect={() => undefined}
-            shortcut={getShortcutKey('Shift+Alt+C')}
             aria-label={t('general.copyToClipboard')}
             disabled={!canCopyAny}
             submenu={
@@ -87,6 +86,7 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({ board }) =
                     copySelectionAsSvg(board).catch(() => undefined);
                   }}
                   disabled={!canCopySvg}
+                  shortcut={getShortcutKey('Shift+Alt+C')}
                   aria-label={t('general.copyToClipboard.svg')}
                 >
                   {t('general.copyToClipboard.svg')}

--- a/packages/drawnix/src/components/toolbar/popup-toolbar/more-options-button.tsx
+++ b/packages/drawnix/src/components/toolbar/popup-toolbar/more-options-button.tsx
@@ -10,6 +10,8 @@ import MenuItem from '../../menu/menu-item';
 import { useState } from 'react';
 import { getShortcutKey } from '../../../utils/common';
 import { canCopySelectionAs, copySelectionAsPng, copySelectionAsSvg } from '../../../utils/image';
+import { MenuItemSwitch } from '../../menu/menu-item-content';
+import { useDrawnix } from '../../../hooks/use-drawnix';
 
 export type MoreOptionsButtonProps = {
   board: PlaitBoard;
@@ -17,6 +19,7 @@ export type MoreOptionsButtonProps = {
 
 export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({ board }) => {
   const { t } = useI18n();
+  const { appState, setAppState } = useDrawnix();
   const container = PlaitBoard.getBoardContainer(board);
   const [menuOpen, setMenuOpen] = useState(false);
   const canCopySvg = canCopySelectionAs('svg');
@@ -96,18 +99,24 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({ board }) =
                     copySelectionAsPng(board).catch(() => undefined);
                   }}
                   disabled={!canCopyPng}
-                  aria-label={t('general.copyToClipboard.pngWithoutBackground')}
+                  aria-label={t('general.copyToClipboard.png')}
                 >
-                  {t('general.copyToClipboard.pngWithoutBackground')}
+                  {t('general.copyToClipboard.png')}
                 </MenuItem>
                 <MenuItem
-                  onSelect={() => {
-                    copySelectionAsPng(board, true).catch(() => undefined);
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    setAppState((currentAppState) => ({
+                      ...currentAppState,
+                      copyTransparent: !currentAppState.copyTransparent,
+                    }));
                   }}
-                  disabled={!canCopyPng}
-                  aria-label={t('general.copyToClipboard.pngWithBackground')}
+                  className="menu-item--setting"
+                  icon={<MenuItemSwitch checked={appState.copyTransparent} />}
+                  shortcut={t('general.copyToClipboard.transparent')}
+                  aria-label={t('general.copyToClipboard.transparent')}
                 >
-                  {t('general.copyToClipboard.pngWithBackground')}
+                  {null}
                 </MenuItem>
               </Menu>
             }

--- a/packages/drawnix/src/components/toolbar/popup-toolbar/more-options-button.tsx
+++ b/packages/drawnix/src/components/toolbar/popup-toolbar/more-options-button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ToolButton } from '../../tool-button';
 import classNames from 'classnames';
 import { useI18n } from '../../../i18n';
@@ -7,10 +7,9 @@ import { MoreOptionsIcon } from '../../icons';
 import { Popover, PopoverContent, PopoverTrigger } from '../../popover/popover';
 import Menu from '../../menu/menu';
 import MenuItem from '../../menu/menu-item';
-import { useState } from 'react';
+import MenuItemContentSwitch from '../../menu/menu-item-content-switch';
 import { getShortcutKey } from '../../../utils/common';
 import { canCopySelectionAs, copySelectionAsPng, copySelectionAsSvg } from '../../../utils/image';
-import { MenuItemSwitch } from '../../menu/menu-item-content';
 import { useDrawnix } from '../../../hooks/use-drawnix';
 
 export type MoreOptionsButtonProps = {
@@ -112,11 +111,13 @@ export const MoreOptionsButton: React.FC<MoreOptionsButtonProps> = ({ board }) =
                     }));
                   }}
                   className="menu-item--setting"
-                  icon={<MenuItemSwitch checked={appState.copyTransparent} />}
-                  shortcut={t('general.copyToClipboard.transparent')}
+                  role="menuitemcheckbox"
+                  aria-checked={appState.copyTransparent}
                   aria-label={t('general.copyToClipboard.transparent')}
                 >
-                  {null}
+                  <MenuItemContentSwitch checked={appState.copyTransparent}>
+                    {t('general.copyToClipboard.transparent')}
+                  </MenuItemContentSwitch>
                 </MenuItem>
               </Menu>
             }

--- a/packages/drawnix/src/drawnix.tsx
+++ b/packages/drawnix/src/drawnix.tsx
@@ -102,6 +102,8 @@ export const Drawnix: React.FC<DrawnixProps> = ({
       fileHandle: null,
       openDialogType: null,
       openCleanConfirm: false,
+      copyTransparent: false,
+      exportTransparent: false,
     };
   });
 

--- a/packages/drawnix/src/hooks/use-drawnix.tsx
+++ b/packages/drawnix/src/hooks/use-drawnix.tsx
@@ -76,6 +76,8 @@ export type DrawnixState = {
   fileHandle: DrawnixFileHandle;
   openDialogType: DialogType | null;
   openCleanConfirm: boolean;
+  copyTransparent: boolean;
+  exportTransparent: boolean;
   linkState?: LinkState | null;
 };
 

--- a/packages/drawnix/src/i18n/translations/ar.ts
+++ b/packages/drawnix/src/i18n/translations/ar.ts
@@ -74,10 +74,10 @@ const arTranslations: Translations = {
   'language.russian': 'Русский',
   'language.arabic': 'عربي',
   'language.vietnamese': 'Tiếng Việt',
-  "general.copyToClipboard": "نسخ إلى الحافظة",
-  "general.copyToClipboard.svg": "SVG",
-  "general.copyToClipboard.png": "PNG",
-  "general.copyToClipboard.transparent": "خلفية شفافة",
+  'general.copyToClipboard': 'نسخ إلى الحافظة',
+  'general.copyToClipboard.svg': 'SVG',
+  'general.copyToClipboard.png': 'PNG',
+  'general.copyToClipboard.transparent': 'خلفية شفافة',
 
   // Menu items
   'menu.open': 'فتح',

--- a/packages/drawnix/src/i18n/translations/ar.ts
+++ b/packages/drawnix/src/i18n/translations/ar.ts
@@ -67,11 +67,6 @@ const arTranslations: Translations = {
   'general.duplicate': 'تكرار',
   'general.delete': 'حذف',
 
-  'general.copyToClipboard': 'نسخ إلى الحافظة',
-  'general.copyToClipboard.svg': 'SVG',
-  'general.copyToClipboard.pngWithoutBackground': 'PNG (بدون خلفية)',
-  'general.copyToClipboard.pngWithBackground': 'PNG (مع خلفية)',
-
   // Language
   'language.switcher': 'اللغة',
   'language.chinese': '中文',
@@ -79,6 +74,10 @@ const arTranslations: Translations = {
   'language.russian': 'Русский',
   'language.arabic': 'عربي',
   'language.vietnamese': 'Tiếng Việt',
+  "general.copyToClipboard": "نسخ إلى الحافظة",
+  "general.copyToClipboard.svg": "SVG",
+  "general.copyToClipboard.png": "PNG",
+  "general.copyToClipboard.transparent": "خلفية شفافة",
 
   // Menu items
   'menu.open': 'فتح',

--- a/packages/drawnix/src/i18n/translations/en.ts
+++ b/packages/drawnix/src/i18n/translations/en.ts
@@ -69,9 +69,8 @@ const enTranslations: Translations = {
   'general.delete': 'Delete',
   'general.copyToClipboard': 'Copy to Clipboard',
   'general.copyToClipboard.svg': 'SVG',
-  'general.copyToClipboard.pngWithoutBackground': 'PNG (no background)',
-  'general.copyToClipboard.pngWithBackground': 'PNG (with background)',
-
+  'general.copyToClipboard.png': 'PNG',
+  'general.copyToClipboard.transparent': 'Transparent',
   // Language
   'language.switcher': 'Language',
   'language.chinese': '中文',

--- a/packages/drawnix/src/i18n/translations/ru.ts
+++ b/packages/drawnix/src/i18n/translations/ru.ts
@@ -70,9 +70,8 @@ const ruTranslations: Translations = {
 
   'general.copyToClipboard': 'Копировать в буфер обмена',
   'general.copyToClipboard.svg': 'SVG',
-  'general.copyToClipboard.pngWithoutBackground': 'PNG (без фона)',
-  'general.copyToClipboard.pngWithBackground': 'PNG (с фоном)',
-
+  'general.copyToClipboard.png': 'PNG',
+  'general.copyToClipboard.transparent': 'Прозрачный фон',
   // Language
   'language.switcher': 'Language',
   'language.chinese': '中文',

--- a/packages/drawnix/src/i18n/translations/vi.ts
+++ b/packages/drawnix/src/i18n/translations/vi.ts
@@ -70,9 +70,8 @@ const viTranslations: Translations = {
 
   'general.copyToClipboard': 'Sao chép vào bộ nhớ tạm',
   'general.copyToClipboard.svg': 'SVG',
-  'general.copyToClipboard.pngWithoutBackground': 'PNG (không nền)',
-  'general.copyToClipboard.pngWithBackground': 'PNG (có nền)',
-
+  'general.copyToClipboard.png': 'PNG',
+  'general.copyToClipboard.transparent': 'Nền trong suốt',
   // Language
   'language.switcher': 'Ngôn ngữ',
   'language.chinese': '中文',

--- a/packages/drawnix/src/i18n/translations/zh.ts
+++ b/packages/drawnix/src/i18n/translations/zh.ts
@@ -70,8 +70,8 @@ const zhTranslations: Translations = {
 
   'general.copyToClipboard': '复制到剪贴板',
   'general.copyToClipboard.svg': 'SVG',
-  'general.copyToClipboard.pngWithoutBackground': 'PNG（无背景）',
-  'general.copyToClipboard.pngWithBackground': 'PNG（含背景）',
+  'general.copyToClipboard.png': 'PNG',
+  'general.copyToClipboard.transparent': '透明背景',
 
   // Language
   'language.switcher': 'Language',

--- a/packages/drawnix/src/i18n/types.ts
+++ b/packages/drawnix/src/i18n/types.ts
@@ -73,8 +73,8 @@ export interface Translations {
   'general.delete': string;
   'general.copyToClipboard': string;
   'general.copyToClipboard.svg': string;
-  'general.copyToClipboard.pngWithoutBackground': string;
-  'general.copyToClipboard.pngWithBackground': string;
+  'general.copyToClipboard.png': string;
+  'general.copyToClipboard.transparent': string;
 
   // Language
   'language.switcher': string;

--- a/packages/drawnix/src/plugins/with-hotkey.ts
+++ b/packages/drawnix/src/plugins/with-hotkey.ts
@@ -3,9 +3,8 @@ import { isHotkey } from 'is-hotkey';
 import {
   addImage,
   canCopySelectionAs,
-  copySelectionAsPng,
   copySelectionAsSvg,
-  saveAsImage,
+  saveAsSvg,
 } from '../utils/image';
 import { saveAsJSON, saveJSON } from '../data/json';
 import {
@@ -46,7 +45,7 @@ export const buildDrawnixHotkeyPlugin = (
         !PlaitBoard.hasBeenTextEditing(board)
       ) {
         if (isHotkey(['mod+shift+e'], { byKey: true })(event)) {
-          saveAsImage(board, true);
+          saveAsSvg(board);
           event.preventDefault();
           return;
         }

--- a/packages/drawnix/src/plugins/with-hotkey.ts
+++ b/packages/drawnix/src/plugins/with-hotkey.ts
@@ -1,11 +1,6 @@
 import { BoardTransforms, getSelectedElements, PlaitBoard, PlaitPointerType } from '@plait/core';
 import { isHotkey } from 'is-hotkey';
-import {
-  addImage,
-  canCopySelectionAs,
-  copySelectionAsSvg,
-  saveAsSvg,
-} from '../utils/image';
+import { addImage, canCopySelectionAs, copySelectionAsSvg, saveAsSvg } from '../utils/image';
 import { saveAsJSON, saveJSON } from '../data/json';
 import {
   DrawnixBoard,

--- a/packages/drawnix/src/plugins/with-hotkey.ts
+++ b/packages/drawnix/src/plugins/with-hotkey.ts
@@ -151,13 +151,8 @@ export const buildDrawnixHotkeyPlugin = (
         }
         if (isHotkey('shift+alt+c')(event)) {
           const canCopySvg = canCopySelectionAs('svg');
-          const canCopyPng = canCopySelectionAs('png');
-          if (canCopySvg || canCopyPng) {
-            if (canCopySvg) {
-              copySelectionAsSvg(board).catch(() => undefined);
-            } else if (canCopyPng) {
-              copySelectionAsPng(board).catch(() => undefined);
-            }
+          if (canCopySvg) {
+            copySelectionAsSvg(board).catch(() => undefined);
             event.preventDefault();
           }
 

--- a/packages/drawnix/src/plugins/with-tool-state-sync.spec.ts
+++ b/packages/drawnix/src/plugins/with-tool-state-sync.spec.ts
@@ -2,10 +2,7 @@ import { PlaitPointerType } from '@plait/core';
 import { BasicShapes } from '@plait/draw';
 import { describe, expect, it, vi } from 'vitest';
 import type { DrawnixBoard } from '../hooks/use-drawnix';
-import {
-  buildToolStateSyncPlugin,
-  syncBoardPointerToToolState,
-} from './with-tool-state-sync';
+import { buildToolStateSyncPlugin, syncBoardPointerToToolState } from './with-tool-state-sync';
 
 vi.mock('@plait/core', () => ({
   PlaitPointerType: {
@@ -64,9 +61,7 @@ describe('tool state pointer sync plugin', () => {
     buildToolStateSyncPlugin(syncToolStatePointer)(board);
     board.pointerUp({} as PointerEvent);
 
-    expect(syncToolStatePointer).toHaveBeenCalledWith(
-      PlaitPointerType.selection
-    );
+    expect(syncToolStatePointer).toHaveBeenCalledWith(PlaitPointerType.selection);
   });
 
   it('skips sync when the board and tool pointers already match', () => {

--- a/packages/drawnix/src/utils/image.ts
+++ b/packages/drawnix/src/utils/image.ts
@@ -57,12 +57,8 @@ const writeBlobToClipboard = async (
   await navigator.clipboard.write([new ClipboardItem(item)]);
 };
 
-const getSvgBlob = async (
-  board: PlaitBoard,
-  isTransparent: boolean,
-  elements?: ExportElements,
-) => {
-  const backgroundColor = getBackgroundColor(board) || "white";
+const getSvgBlob = async (board: PlaitBoard, isTransparent: boolean, elements?: ExportElements) => {
+  const backgroundColor = getBackgroundColor(board) || 'white';
   const fillStyle = isTransparent ? TRANSPARENT : backgroundColor;
   const svgData = await toSvgData(board, {
     fillStyle,
@@ -89,8 +85,7 @@ const getImageBlob = async (
 };
 
 export const saveAsSvg = (board: PlaitBoard) => {
-  const exportTransparent = !!(board as DrawnixBoard).appState
-    ?.exportTransparent;
+  const exportTransparent = !!(board as DrawnixBoard).appState?.exportTransparent;
   const selectedElements = getSelectedElements(board);
   return getSvgBlob(
     board,
@@ -103,8 +98,7 @@ export const saveAsSvg = (board: PlaitBoard) => {
 };
 
 export const saveAsPng = (board: PlaitBoard) => {
-  const exportTransparent = !!(board as DrawnixBoard).appState
-    ?.exportTransparent;
+  const exportTransparent = !!(board as DrawnixBoard).appState?.exportTransparent;
   const selectedElements = getSelectedElements(board);
   getImageBlob(
     board,
@@ -138,11 +132,7 @@ export const copySelectionAsPng = async (board: PlaitBoard) => {
   if (selectedElements.length === 0) {
     return;
   }
-  const imageBlob = await getImageBlob(
-    board,
-    copyTransparent,
-    selectedElements,
-  );
+  const imageBlob = await getImageBlob(board, copyTransparent, selectedElements);
   if (!imageBlob) {
     return;
   }

--- a/packages/drawnix/src/utils/image.ts
+++ b/packages/drawnix/src/utils/image.ts
@@ -1,25 +1,26 @@
-import { getSelectedElements, PlaitBoard, toSvgData } from '@plait/core';
-import { base64ToBlob, boardToImage, download } from './common';
-import { fileOpen } from '../data/filesystem';
-import { IMAGE_MIME_TYPES } from '../constants';
-import { insertImage } from '../data/image';
-import { getBackgroundColor, isWhite } from './color';
-import { TRANSPARENT } from '../constants/color';
+import { getSelectedElements, PlaitBoard, toSvgData } from "@plait/core";
+import { base64ToBlob, boardToImage, download } from "./common";
+import { fileOpen } from "../data/filesystem";
+import { IMAGE_MIME_TYPES } from "../constants";
+import { insertImage } from "../data/image";
+import { getBackgroundColor } from "./color";
+import { TRANSPARENT } from "../constants/color";
+import type { DrawnixBoard } from "../hooks/use-drawnix";
 
-type ClipboardImageFormat = 'svg' | 'png';
+type ClipboardImageFormat = "svg" | "png";
 type ExportElements = ReturnType<typeof getSelectedElements>;
 
 const CLIPBOARD_MIME_TYPES: Record<ClipboardImageFormat, string> = {
-  svg: 'image/svg+xml',
-  png: 'image/png',
+  svg: "image/svg+xml",
+  png: "image/png",
 };
 
 const hasClipboardWriteSupport = () => {
   // Keep the ClipboardItem check local until the shared helper also covers it.
   return (
-    typeof navigator !== 'undefined' &&
+    typeof navigator !== "undefined" &&
     !!navigator.clipboard?.write &&
-    typeof ClipboardItem !== 'undefined'
+    typeof ClipboardItem !== "undefined"
   );
 };
 
@@ -35,16 +36,16 @@ export const canCopySelectionAs = (format: ClipboardImageFormat) => {
     return false;
   }
   const supports = getClipboardItemSupports();
-  if (typeof supports === 'function') {
+  if (typeof supports === "function") {
     return supports(CLIPBOARD_MIME_TYPES[format]);
   }
-  return format === 'png';
+  return format === "png";
 };
 
 const writeBlobToClipboard = async (
   format: ClipboardImageFormat,
   blob: Blob | null,
-  fallbackPngBlob?: Blob | null
+  fallbackPngBlob?: Blob | null,
 ) => {
   if (!blob || !hasClipboardWriteSupport()) {
     return;
@@ -56,15 +57,20 @@ const writeBlobToClipboard = async (
   await navigator.clipboard.write([new ClipboardItem(item)]);
 };
 
-const getSvgBlob = async (board: PlaitBoard, elements?: ExportElements) => {
-  const backgroundColor = getBackgroundColor(board);
+const getSvgBlob = async (
+  board: PlaitBoard,
+  isTransparent: boolean,
+  elements?: ExportElements,
+) => {
+  const backgroundColor = getBackgroundColor(board) || "white";
+  const fillStyle = isTransparent ? TRANSPARENT : backgroundColor;
   const svgData = await toSvgData(board, {
-    fillStyle: isWhite(backgroundColor) ? TRANSPARENT : backgroundColor,
+    fillStyle,
     padding: 20,
     ratio: 4,
     elements,
-    inlineStyleClassNames: '.plait-text-container',
-    styleNames: ['position'],
+    inlineStyleClassNames: ".plait-text-container",
+    styleNames: ["position"],
   });
   return new Blob([svgData], { type: CLIPBOARD_MIME_TYPES.svg });
 };
@@ -72,35 +78,41 @@ const getSvgBlob = async (board: PlaitBoard, elements?: ExportElements) => {
 const getImageBlob = async (
   board: PlaitBoard,
   isTransparent: boolean,
-  elements?: ExportElements
+  elements?: ExportElements,
 ) => {
-  const backgroundColor = getBackgroundColor(board) || 'white';
+  const backgroundColor = getBackgroundColor(board) || "white";
   const imageDataUrl = await boardToImage(board, {
     elements,
-    fillStyle: isTransparent ? 'transparent' : backgroundColor,
+    fillStyle: isTransparent ? "transparent" : backgroundColor,
   });
   return imageDataUrl ? base64ToBlob(imageDataUrl) : null;
 };
 
 export const saveAsSvg = (board: PlaitBoard) => {
+  const exportTransparent = !!(board as DrawnixBoard).appState
+    ?.exportTransparent;
   const selectedElements = getSelectedElements(board);
-  return getSvgBlob(board, selectedElements.length > 0 ? selectedElements : undefined).then(
-    (blob) => {
-      const imageName = `drawnix-${new Date().getTime()}.svg`;
-      download(blob, imageName);
-    }
-  );
+  return getSvgBlob(
+    board,
+    exportTransparent,
+    selectedElements.length > 0 ? selectedElements : undefined,
+  ).then((blob) => {
+    const imageName = `drawnix-${new Date().getTime()}.svg`;
+    download(blob, imageName);
+  });
 };
 
-export const saveAsImage = (board: PlaitBoard, isTransparent: boolean) => {
+export const saveAsPng = (board: PlaitBoard) => {
+  const exportTransparent = !!(board as DrawnixBoard).appState
+    ?.exportTransparent;
   const selectedElements = getSelectedElements(board);
   getImageBlob(
     board,
-    isTransparent,
-    selectedElements.length > 0 ? selectedElements : undefined
+    exportTransparent,
+    selectedElements.length > 0 ? selectedElements : undefined,
   ).then((imageBlob) => {
     if (imageBlob) {
-      const ext = isTransparent ? 'png' : 'jpg';
+      const ext = "png";
       const imageName = `drawnix-${new Date().getTime()}.${ext}`;
       download(imageBlob, imageName);
     }
@@ -108,35 +120,43 @@ export const saveAsImage = (board: PlaitBoard, isTransparent: boolean) => {
 };
 
 export const copySelectionAsSvg = async (board: PlaitBoard) => {
+  const copyTransparent = !!(board as DrawnixBoard).appState?.copyTransparent;
   const selectedElements = getSelectedElements(board);
   if (selectedElements.length === 0) {
     return;
   }
   const [blob, pngBlob] = await Promise.all([
-    getSvgBlob(board, selectedElements),
-    getImageBlob(board, true, selectedElements),
+    getSvgBlob(board, copyTransparent, selectedElements),
+    getImageBlob(board, copyTransparent, selectedElements),
   ]);
-  await writeBlobToClipboard('svg', blob, pngBlob);
+  await writeBlobToClipboard("svg", blob, pngBlob);
 };
 
-export const copySelectionAsPng = async (board: PlaitBoard, withBackground = false) => {
+export const copySelectionAsPng = async (board: PlaitBoard) => {
+  const copyTransparent = !!(board as DrawnixBoard).appState?.copyTransparent;
   const selectedElements = getSelectedElements(board);
   if (selectedElements.length === 0) {
     return;
   }
-  const imageBlob = await getImageBlob(board, !withBackground, selectedElements);
+  const imageBlob = await getImageBlob(
+    board,
+    copyTransparent,
+    selectedElements,
+  );
   if (!imageBlob) {
     return;
   }
   // The clipboard only gets image/png. The background choice is controlled by
   // how the image is rendered before writing to the clipboard.
-  await writeBlobToClipboard('png', imageBlob);
+  await writeBlobToClipboard("png", imageBlob);
 };
 
 export const addImage = async (board: PlaitBoard) => {
   const imageFile = await fileOpen({
-    description: 'Image',
-    extensions: Object.keys(IMAGE_MIME_TYPES) as (keyof typeof IMAGE_MIME_TYPES)[],
+    description: "Image",
+    extensions: Object.keys(
+      IMAGE_MIME_TYPES,
+    ) as (keyof typeof IMAGE_MIME_TYPES)[],
   });
   insertImage(board, imageFile);
 };

--- a/packages/drawnix/src/utils/image.ts
+++ b/packages/drawnix/src/utils/image.ts
@@ -1,26 +1,26 @@
-import { getSelectedElements, PlaitBoard, toSvgData } from "@plait/core";
-import { base64ToBlob, boardToImage, download } from "./common";
-import { fileOpen } from "../data/filesystem";
-import { IMAGE_MIME_TYPES } from "../constants";
-import { insertImage } from "../data/image";
-import { getBackgroundColor } from "./color";
-import { TRANSPARENT } from "../constants/color";
-import type { DrawnixBoard } from "../hooks/use-drawnix";
+import { getSelectedElements, PlaitBoard, toSvgData } from '@plait/core';
+import { base64ToBlob, boardToImage, download } from './common';
+import { fileOpen } from '../data/filesystem';
+import { IMAGE_MIME_TYPES } from '../constants';
+import { insertImage } from '../data/image';
+import { getBackgroundColor } from './color';
+import { TRANSPARENT } from '../constants/color';
+import type { DrawnixBoard } from '../hooks/use-drawnix';
 
-type ClipboardImageFormat = "svg" | "png";
+type ClipboardImageFormat = 'svg' | 'png';
 type ExportElements = ReturnType<typeof getSelectedElements>;
 
 const CLIPBOARD_MIME_TYPES: Record<ClipboardImageFormat, string> = {
-  svg: "image/svg+xml",
-  png: "image/png",
+  svg: 'image/svg+xml',
+  png: 'image/png',
 };
 
 const hasClipboardWriteSupport = () => {
   // Keep the ClipboardItem check local until the shared helper also covers it.
   return (
-    typeof navigator !== "undefined" &&
+    typeof navigator !== 'undefined' &&
     !!navigator.clipboard?.write &&
-    typeof ClipboardItem !== "undefined"
+    typeof ClipboardItem !== 'undefined'
   );
 };
 
@@ -36,16 +36,16 @@ export const canCopySelectionAs = (format: ClipboardImageFormat) => {
     return false;
   }
   const supports = getClipboardItemSupports();
-  if (typeof supports === "function") {
+  if (typeof supports === 'function') {
     return supports(CLIPBOARD_MIME_TYPES[format]);
   }
-  return format === "png";
+  return format === 'png';
 };
 
 const writeBlobToClipboard = async (
   format: ClipboardImageFormat,
   blob: Blob | null,
-  fallbackPngBlob?: Blob | null,
+  fallbackPngBlob?: Blob | null
 ) => {
   if (!blob || !hasClipboardWriteSupport()) {
     return;
@@ -65,8 +65,8 @@ const getSvgBlob = async (board: PlaitBoard, isTransparent: boolean, elements?: 
     padding: 20,
     ratio: 4,
     elements,
-    inlineStyleClassNames: ".plait-text-container",
-    styleNames: ["position"],
+    inlineStyleClassNames: '.plait-text-container',
+    styleNames: ['position'],
   });
   return new Blob([svgData], { type: CLIPBOARD_MIME_TYPES.svg });
 };
@@ -74,12 +74,12 @@ const getSvgBlob = async (board: PlaitBoard, isTransparent: boolean, elements?: 
 const getImageBlob = async (
   board: PlaitBoard,
   isTransparent: boolean,
-  elements?: ExportElements,
+  elements?: ExportElements
 ) => {
-  const backgroundColor = getBackgroundColor(board) || "white";
+  const backgroundColor = getBackgroundColor(board) || 'white';
   const imageDataUrl = await boardToImage(board, {
     elements,
-    fillStyle: isTransparent ? "transparent" : backgroundColor,
+    fillStyle: isTransparent ? 'transparent' : backgroundColor,
   });
   return imageDataUrl ? base64ToBlob(imageDataUrl) : null;
 };
@@ -90,7 +90,7 @@ export const saveAsSvg = (board: PlaitBoard) => {
   return getSvgBlob(
     board,
     exportTransparent,
-    selectedElements.length > 0 ? selectedElements : undefined,
+    selectedElements.length > 0 ? selectedElements : undefined
   ).then((blob) => {
     const imageName = `drawnix-${new Date().getTime()}.svg`;
     download(blob, imageName);
@@ -103,10 +103,10 @@ export const saveAsPng = (board: PlaitBoard) => {
   getImageBlob(
     board,
     exportTransparent,
-    selectedElements.length > 0 ? selectedElements : undefined,
+    selectedElements.length > 0 ? selectedElements : undefined
   ).then((imageBlob) => {
     if (imageBlob) {
-      const ext = "png";
+      const ext = 'png';
       const imageName = `drawnix-${new Date().getTime()}.${ext}`;
       download(imageBlob, imageName);
     }
@@ -123,7 +123,7 @@ export const copySelectionAsSvg = async (board: PlaitBoard) => {
     getSvgBlob(board, copyTransparent, selectedElements),
     getImageBlob(board, copyTransparent, selectedElements),
   ]);
-  await writeBlobToClipboard("svg", blob, pngBlob);
+  await writeBlobToClipboard('svg', blob, pngBlob);
 };
 
 export const copySelectionAsPng = async (board: PlaitBoard) => {
@@ -138,15 +138,13 @@ export const copySelectionAsPng = async (board: PlaitBoard) => {
   }
   // The clipboard only gets image/png. The background choice is controlled by
   // how the image is rendered before writing to the clipboard.
-  await writeBlobToClipboard("png", imageBlob);
+  await writeBlobToClipboard('png', imageBlob);
 };
 
 export const addImage = async (board: PlaitBoard) => {
   const imageFile = await fileOpen({
-    description: "Image",
-    extensions: Object.keys(
-      IMAGE_MIME_TYPES,
-    ) as (keyof typeof IMAGE_MIME_TYPES)[],
+    description: 'Image',
+    extensions: Object.keys(IMAGE_MIME_TYPES) as (keyof typeof IMAGE_MIME_TYPES)[],
   });
   insertImage(board, imageFile);
 };


### PR DESCRIPTION
## PR #423 Summary (vs `origin/develop`)

- 19 files changed: +243 / -77
- Main themes: submenu UI improvements, “transparent background” toggle for copy/export (state-driven), and hotkey/export/copy behavior alignment.

### Menu System (Core Components)

- **Submenu indicator**
  - Adds a right-chevron icon and shows it on menu items that have a submenu, improving discoverability.

- **`MenuItem` supports “content components”**
  - Allows certain specialized children (e.g. switch layout) to render directly, while standard menu items still use the default `MenuItemContent` wrapper.
  - This enables richer menu rows without adding extra props like `content`.

- **Switch UI building blocks**
  - Introduces a visual-only switch component (hidden from assistive tech).
  - Introduces a switch content layout component that places the switch on the left and the label on the right (aligned and styled like secondary text).

- **Menu styling upgrades**
  - Adds minimum width, improves right-side alignment, adds “setting row” styling, tweaks shortcut typography, and introduces switch visuals.

- **`Menu` supports per-container styling**
  - Adds a way to customize submenu container sizing independently (useful for narrower submenus).

### Toolbar Integration (Product UI)

- **More Options → Copy to Clipboard becomes a submenu**
  - Parent item no longer shows a shortcut; shortcut is shown on the specific submenu item (“Copy as SVG”).
  - PNG options are merged into a single item.
  - Adds a “Transparent background” toggle row implemented as a checkbox-like menu item and kept open when toggled.

- **App Toolbar → Export Image becomes a submenu**
  - Export menu becomes a submenu with SVG/PNG export items plus a “Transparent background” toggle row (same behavior pattern).

### Copy/Export Logic (Behavior Changes)

- **Transparency is state-driven via app state**
  - Copy transparency and export transparency are read from global board/app state instead of being passed around as parameters.
  - Export and copy functions now consistently respect these state flags.

- **API updates**
  - Renames/export helpers to reflect PNG export explicitly.
  - Removes “withBackground” parameter style for clipboard PNG; background choice is controlled by the transparency state.

### Global State

- Adds `copyTransparent` and `exportTransparent` to the global `DrawnixState`.
- Initializes both flags to `false`.

### Hotkey Changes

- `mod+shift+e`: now exports SVG.
- `shift+alt+c`: now only copies SVG when supported (removes PNG fallback behavior).

### i18n Updates

- Replaces two PNG-related keys (with/without background) with:
  - a single `PNG` label
  - a separate `Transparent` label
- Updates all translation files accordingly.

### Review Focus Points

- **Accessibility & interaction**
  - Checkbox-like menu items use `role="menuitemcheckbox"` + `aria-checked`.
  - Toggle rows use `preventDefault()` to keep the menu open—confirm this matches expected UX everywhere.

- **Behavior changes**
  - Confirm hotkey changes are acceptable (no more PNG fallback on `shift+alt+c`).
  - Confirm export/copy outputs match the new transparency state behavior.

- **Architecture trade-off**
  - The “content component” convention in `MenuItem` relies on a flagged child component pattern; this becomes a soft contract for future custom menu-row layouts.