### PR TITLE
fix(toolbar): sync grouped tool icons

### DIFF
--- a/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/creation-toolbar.tsx
@@ -164,6 +164,18 @@ export const CreationToolbar = () => {
     ) ||
     BUTTONS.find((button) => button.key === PopupKey.freehand) ||
     BUTTONS[4];
+  const currentShapePointer = isShapeMenuPointer(toolState.pointer)
+    ? toolState.pointer
+    : toolState.lastShapePointer;
+  const currentArrowPointer = isArrowLinePointerType(toolState.pointer)
+    ? toolState.pointer
+    : toolState.lastArrowPointer;
+  const lastShapeButton = SHAPES.find(
+    (shape) => shape.pointer === currentShapePointer
+  );
+  const lastArrowButton = ARROWS.find(
+    (arrow) => arrow.pointer === currentArrowPointer
+  );
 
   const updateToolState = (nextToolState: Partial<DrawnixToolState>) => {
     setAppState((currentAppState) => ({
@@ -334,7 +346,7 @@ export const CreationToolbar = () => {
                       (isShapePointer(board) &&
                         !PlaitBoard.isPointer(board, BasicShapes.text))
                     }
-                    icon={button.icon}
+                    icon={lastShapeButton?.icon || button.icon}
                     title={button.titleKey ? t(button.titleKey) : 'Shape'}
                     aria-label={button.titleKey ? t(button.titleKey) : 'Shape'}
                     onPointerDown={() => {
@@ -383,7 +395,7 @@ export const CreationToolbar = () => {
                     type="icon"
                     visible={true}
                     selected={arrowOpen || isArrowLinePointer(board)}
-                    icon={button.icon}
+                    icon={lastArrowButton?.icon || button.icon}
                     title={button.titleKey ? t(button.titleKey) : ''}
                     aria-label={button.titleKey ? t(button.titleKey) : ''}
                     onPointerDown={() => {


### PR DESCRIPTION
## Summary

This is a small display-only toolbar update for #420.

- Update the top-level shape toolbar icon to reuse the currently selected shape sub-tool SVG.
- Update the top-level arrow toolbar icon to reuse the currently selected arrow sub-tool SVG.
- Keep existing behavior intact by falling back to the original category icon when no matching sub-tool icon is found.

This does not change tool state persistence, reload behavior, or secondary panel behavior.

Closes #420

## Validation

- `npm exec nx run drawnix:typecheck`
- `npm exec nx run drawnix:test -- --run`
- Manual preview at `http://127.0.0.1:4300/`: selected diamond shape and curve arrow, confirmed the top-level toolbar icons updated accordingly.