### PR TITLE
fix: sync tool pointer after drawing

### DIFF
--- a/packages/drawnix/src/drawnix.tsx
+++ b/packages/drawnix/src/drawnix.tsx
@@ -25,6 +25,7 @@ import { AppToolbar } from './components/toolbar/app-toolbar/app-toolbar';
 import classNames from 'classnames';
 import './styles/index.scss';
 import { buildDrawnixHotkeyPlugin } from './plugins/with-hotkey';
+import { buildToolStateSyncPlugin } from './plugins/with-tool-state-sync';
 import { withFreehand } from './plugins/freehand/with-freehand';
 import { ThemeToolbar } from './components/toolbar/theme-toolbar';
 import { buildPencilPlugin } from './plugins/with-pencil';
@@ -132,6 +133,21 @@ export const Drawnix: React.FC<DrawnixProps> = ({
     }));
   };
 
+  const syncBoardPointerToToolState = (pointer: DrawnixToolState['pointer']) => {
+    setAppState((currentAppState) => {
+      if (currentAppState.toolState.pointer === pointer) {
+        return currentAppState;
+      }
+      return {
+        ...currentAppState,
+        toolState: {
+          ...currentAppState.toolState,
+          pointer,
+        },
+      };
+    });
+  };
+
   const plugins: PlaitPlugin[] = [
     withDraw,
     withGroup,
@@ -142,6 +158,7 @@ export const Drawnix: React.FC<DrawnixProps> = ({
     withFreehand,
     buildPencilPlugin(updateAppState),
     buildTextLinkPlugin(updateAppState),
+    buildToolStateSyncPlugin(syncBoardPointerToToolState),
   ];
 
   const containerRef = useRef<HTMLDivElement>(null);

--- a/packages/drawnix/src/plugins/with-tool-state-sync.spec.ts
+++ b/packages/drawnix/src/plugins/with-tool-state-sync.spec.ts
@@ -1,0 +1,80 @@
+import { PlaitPointerType } from '@plait/core';
+import { BasicShapes } from '@plait/draw';
+import { describe, expect, it, vi } from 'vitest';
+import type { DrawnixBoard } from '../hooks/use-drawnix';
+import {
+  buildToolStateSyncPlugin,
+  syncBoardPointerToToolState,
+} from './with-tool-state-sync';
+
+vi.mock('@plait/core', () => ({
+  PlaitPointerType: {
+    hand: 'hand',
+    selection: 'selection',
+  },
+}));
+
+vi.mock('@plait/draw', () => ({
+  ArrowLineShape: {
+    straight: 'straight',
+  },
+  BasicShapes: {
+    rectangle: 'rectangle',
+  },
+}));
+
+vi.mock('@plait/mind', () => ({
+  MindPointerType: {
+    mind: 'mind',
+  },
+}));
+
+vi.mock('../plugins/freehand/type', () => ({
+  FreehandShape: {
+    feltTipPen: 'feltTipPen',
+    eraser: 'eraser',
+  },
+}));
+
+const createBoard = (): DrawnixBoard =>
+  ({
+    pointer: BasicShapes.rectangle,
+    appState: {
+      toolState: {
+        pointer: BasicShapes.rectangle,
+        lastShapePointer: BasicShapes.rectangle,
+        lastArrowPointer: 'straight',
+        lastFreehandPointer: 'feltTipPen',
+        activeFreehandPresetIndex: 0,
+        freehandPresets: [],
+      },
+    },
+    pointerUp: vi.fn(),
+    globalPointerUp: vi.fn(),
+  }) as unknown as DrawnixBoard;
+
+describe('tool state pointer sync plugin', () => {
+  it('syncs the board pointer after pointer up handlers run', () => {
+    const board = createBoard();
+    const syncToolStatePointer = vi.fn();
+    board.pointerUp = vi.fn(() => {
+      board.pointer = PlaitPointerType.selection;
+    });
+
+    buildToolStateSyncPlugin(syncToolStatePointer)(board);
+    board.pointerUp({} as PointerEvent);
+
+    expect(syncToolStatePointer).toHaveBeenCalledWith(
+      PlaitPointerType.selection
+    );
+  });
+
+  it('skips sync when the board and tool pointers already match', () => {
+    const board = createBoard();
+    const syncToolStatePointer = vi.fn();
+
+    syncBoardPointerToToolState(board, syncToolStatePointer);
+
+    expect(syncToolStatePointer).not.toHaveBeenCalled();
+  });
+});

--- a/packages/drawnix/src/plugins/with-tool-state-sync.ts
+++ b/packages/drawnix/src/plugins/with-tool-state-sync.ts
@@ -1,0 +1,37 @@
+import type { PlaitBoard } from '@plait/core';
+import type { DrawnixBoard, DrawnixPointerType } from '../hooks/use-drawnix';
+
+export const syncBoardPointerToToolState = (
+  board: PlaitBoard,
+  syncToolStatePointer: (pointer: DrawnixPointerType) => void
+) => {
+  const toolState = (board as DrawnixBoard).appState?.toolState;
+
+  if (!toolState || toolState.pointer === board.pointer) {
+    return;
+  }
+
+  syncToolStatePointer(board.pointer as DrawnixPointerType);
+};
+
+export const buildToolStateSyncPlugin = (
+  syncToolStatePointer: (pointer: DrawnixPointerType) => void
+) => {
+  const withToolStateSync = (board: PlaitBoard) => {
+    const { pointerUp, globalPointerUp } = board;
+
+    board.pointerUp = (event: PointerEvent) => {
+      pointerUp(event);
+      syncBoardPointerToToolState(board, syncToolStatePointer);
+    };
+
+    board.globalPointerUp = (event: PointerEvent) => {
+      globalPointerUp(event);
+      syncBoardPointerToToolState(board, syncToolStatePointer);
+    };
+
+    return board;
+  };
+
+  return withToolStateSync;
+};


### PR DESCRIPTION
## Summary

This is a small follow-up to #416.

#416 persists and restores the selected tool state after reload. After that PR was merged, we noticed one remaining mismatch: drawing a shape or arrow visually switches the board pointer back to selection, but the persisted Drawnix tool state could still keep the previous shape or arrow pointer. On reload, that stale persisted pointer restored the drawing tool instead of selection.

This PR adds a narrow pointer-sync plugin that runs after pointer-up handling and copies the final `board.pointer` back into `toolState.pointer` when they differ.

## Root Cause

`@plait/draw` switches `board.pointer` to `selection` after inserting shape / arrow elements. That pointer reset does not go through Drawnix toolbar state updates, so `toolState.pointer` could remain stale.

## Validation

- `npx vitest run src/hooks/use-drawnix.spec.ts src/plugins/with-tool-state-sync.spec.ts --config vite.config.ts`
- `npx tsc -p packages/drawnix/tsconfig.lib.json --noEmit`
- `npx tsc -p packages/drawnix/tsconfig.spec.json --noEmit`
- Manual browser check: shape -> draw -> reload keeps selection
- Manual browser check: arrow -> draw -> reload keeps selection

## BTW

I had seen this behavior myself: after drawing a shape or arrow, the toolbar visually switched to selection, but after reload it returned to the shape or arrow tool. I initially thought that was the intended behavior, so I did not treat it as a bug in #416.