### PR TITLE
chore: modernize Sass module imports

### DIFF
--- a/packages/drawnix/src/components/menu/menu.scss
+++ b/packages/drawnix/src/components/menu/menu.scss
@@ -1,4 +1,4 @@
-@import "../../styles/variables.module.scss";
+@use '../../styles/variables.module.scss' as *;
 
 .drawnix {
   .menu {

--- a/packages/drawnix/src/components/radio-group.scss
+++ b/packages/drawnix/src/components/radio-group.scss
@@ -1,4 +1,4 @@
-@import '../styles/variables.module.scss';
+@use '../styles/variables.module.scss' as *;
 
 .drawnix {
   --RadioGroup-background: var(--island-bg-color);

--- a/packages/drawnix/src/components/tool-icon.scss
+++ b/packages/drawnix/src/components/tool-icon.scss
@@ -1,4 +1,4 @@
-@import "../styles/variables.module.scss";
+@use '../styles/variables.module.scss' as *;
 
 .drawnix {
   .tool-icon {

--- a/packages/drawnix/src/components/ttd-dialog/ttd-dialog.scss
+++ b/packages/drawnix/src/components/ttd-dialog/ttd-dialog.scss
@@ -1,4 +1,4 @@
-@import "../../styles/variables.module.scss";
+@use '../../styles/variables.module.scss' as *;
 
 $verticalBreakpoint: 861px;
 

--- a/packages/drawnix/src/styles/index.scss
+++ b/packages/drawnix/src/styles/index.scss
@@ -1,6 +1,7 @@
-@import './../../../../node_modules/@plait/draw/styles/styles.scss';
-@import './../../../../node_modules/@plait/mind/styles/styles.scss';
-@import './theme.scss';
+@use './../../../../node_modules/@plait/draw/styles/styles.scss' as *;
+@use './../../../../node_modules/@plait/mind/styles/styles.scss' as *;
+@use './variables.module.scss' as *;
+@use './theme.scss' as *;
 
 .drawnix {
     height: 100%;

--- a/packages/drawnix/src/styles/theme.scss
+++ b/packages/drawnix/src/styles/theme.scss
@@ -1,4 +1,4 @@
-@import "./variables.module.scss";
+@use './variables.module.scss' as *;
 
 .drawnix {
   --focus-highlight-color: #a5d8ff;

--- a/packages/drawnix/src/styles/variables.module.scss
+++ b/packages/drawnix/src/styles/variables.module.scss
@@ -1,3 +1,5 @@
+@use 'sass:string';
+
 @mixin isMobile() {
   @at-root .drawnix--mobile#{&} {
     @content;
@@ -123,6 +125,6 @@ $theme-filter: "invert(93%) hue-rotate(180deg)";
 $right-sidebar-width: "302px";
 
 :export {
-  themeFilter: unquote($theme-filter);
-  rightSidebarWidth: unquote($right-sidebar-width);
+  themeFilter: string.unquote($theme-filter);
+  rightSidebarWidth: string.unquote($right-sidebar-width);
 }


### PR DESCRIPTION
## Summary

- Replace the remaining Drawnix SCSS `@import` rules with Sass module `@use` imports.
- Explicitly load `variables.module.scss` from `styles/index.scss`, because `@use` does not implicitly forward members through another stylesheet.
- Replace global `unquote()` calls with `string.unquote()` from the official `sass:string` module.

## Why

This is Phase 4 of #417 and is intended as preparation for the later Sass upgrade in the toolchain roadmap.

Sass officially documents `@import` and global built-in functions as deprecated and recommends migrating to the module system (`@use` / `@forward`) and built-in modules such as `sass:string`:

- https://sass-lang.com/documentation/breaking-changes/import/
- https://sass-lang.com/blog/import-is-deprecated/

Updating these usages now keeps the future Sass upgrade smaller and avoids mixing dependency upgrades with syntax migration warnings.

This PR should not change runtime styling behavior. It is a maintenance step that is worth doing before the larger Nx / Vite / TypeScript / Sass upgrade phases because it removes deprecated Sass surface area while the current Sass version already supports the module system.

## Validation

- `npx nx build drawnix`
- `npx nx build web`