### PR TITLE
feat(drawnix): support global toast

### DIFF
--- a/packages/drawnix/src/components/toast/toast.scss
+++ b/packages/drawnix/src/components/toast/toast.scss
@@ -1,0 +1,46 @@
+.drawnix-toast-wrapper {
+    position: absolute;
+    z-index: 2023;
+    bottom: 36px;
+    left: 50%;
+    max-width: calc(100% - 48px);
+    pointer-events: none;
+    transform: translateX(-50%);
+}
+
+.drawnix-toast {
+    min-width: 280px;
+    max-width: 560px;
+    padding: 16px 28px;
+    border: 1px solid var(--color-border-outline-variant);
+    border-radius: 12px;
+    background: var(--color-surface-lowest);
+    box-shadow: var(--shadow-island);
+    color: var(--text-primary-color);
+    font-size: 16px;
+    line-height: 1.6;
+    text-align: center;
+    word-break: break-word;
+}
+
+.drawnix-toast__message {
+    font-weight: 500;
+}
+
+.drawnix-toast__description {
+    margin-top: 2px;
+}
+
+.drawnix--mobile {
+    .drawnix-toast-wrapper {
+        bottom: 92px;
+        max-width: calc(100% - 32px);
+    }
+
+    .drawnix-toast {
+        min-width: 0;
+        width: 100%;
+        padding: 12px 16px;
+        font-size: 14px;
+    }
+}

--- a/packages/drawnix/src/components/toast/toast.scss
+++ b/packages/drawnix/src/components/toast/toast.scss
@@ -3,32 +3,76 @@
     z-index: 2023;
     bottom: 36px;
     left: 50%;
-    max-width: calc(100% - 48px);
+    max-width: calc(100% - 32px);
     pointer-events: none;
     transform: translateX(-50%);
 }
 
 .drawnix-toast {
-    min-width: 280px;
-    max-width: 560px;
-    padding: 16px 28px;
-    border: 1px solid var(--color-border-outline-variant);
-    border-radius: 12px;
-    background: var(--color-surface-lowest);
-    box-shadow: var(--shadow-island);
-    color: var(--text-primary-color);
-    font-size: 16px;
-    line-height: 1.6;
+    min-width: 220px;
+    max-width: min(420px, calc(100vw - 32px));
+    box-sizing: border-box;
+    padding: 10px 16px;
+    border: 1px solid var(--toast-border-color, var(--island-border-color));
+    border-radius: var(--border-radius-md);
+    background: var(--toast-bg-color, var(--island-bg-color));
+    box-shadow: var(--toast-shadow, var(--shadow-island));
+    color: var(--toast-text-color, var(--color-gray-90));
+    font-size: 14px;
+    line-height: 1.5;
     text-align: center;
     word-break: break-word;
 }
 
 .drawnix-toast__message {
-    font-weight: 500;
+    font-weight: 400;
 }
 
 .drawnix-toast__description {
-    margin-top: 2px;
+    margin-top: 1px;
+    color: var(--toast-description-color, var(--color-on-surface));
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+.drawnix {
+    &.theme--default,
+    &.theme--colorful {
+        --toast-bg-color: var(--island-bg-color);
+        --toast-border-color: var(--island-border-color);
+        --toast-text-color: var(--color-gray-90);
+        --toast-description-color: var(--color-gray-70);
+    }
+
+    &.theme--soft {
+        --toast-bg-color: #ffffff;
+        --toast-border-color: var(--color-gray-20);
+        --toast-text-color: var(--color-gray-90);
+        --toast-description-color: var(--color-gray-70);
+    }
+
+    &.theme--retro {
+        --toast-bg-color: #fffdf2;
+        --toast-border-color: #e4dfc6;
+        --toast-text-color: #4f4a34;
+        --toast-description-color: #77704f;
+    }
+
+    &.theme--dark {
+        --toast-bg-color: var(--color-gray-85);
+        --toast-border-color: var(--color-gray-80);
+        --toast-text-color: var(--color-gray-10);
+        --toast-description-color: var(--color-gray-30);
+        --toast-shadow: 0 8px 24px #00000040;
+    }
+
+    &.theme--starry {
+        --toast-bg-color: #153047;
+        --toast-border-color: #284b66;
+        --toast-text-color: #f5fbff;
+        --toast-description-color: #c8d9e6;
+        --toast-shadow: 0 8px 24px #00111f66;
+    }
 }
 
 .drawnix--mobile {
@@ -40,7 +84,7 @@
     .drawnix-toast {
         min-width: 0;
         width: 100%;
-        padding: 12px 16px;
-        font-size: 14px;
+        padding: 9px 14px;
+        font-size: 13px;
     }
 }

--- a/packages/drawnix/src/components/toast/toast.spec.tsx
+++ b/packages/drawnix/src/components/toast/toast.spec.tsx
@@ -1,8 +1,23 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
-import { Toast } from './toast';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_TOAST_DURATION, Toast, useToast } from './toast';
+
+const ToastHarness = ({ duration }: { duration?: number }) => {
+  const { toast, showToast } = useToast();
+
+  return (
+    <>
+      <button onClick={() => showToast({ message: 'Toast message', duration })}>show</button>
+      <Toast toast={toast} />
+    </>
+  );
+};
 
 describe('Toast', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('does not render empty toast content', () => {
     const { container } = render(<Toast toast={null} />);
 
@@ -41,5 +56,24 @@ describe('Toast', () => {
       'Copied selected items as PNG to clipboard'
     );
     expect(screen.getByText('(Transparent background)')).toBeTruthy();
+  });
+
+  it('uses a 4s default duration before hiding the toast', () => {
+    vi.useFakeTimers();
+
+    render(<ToastHarness />);
+    fireEvent.click(screen.getByRole('button', { name: 'show' }));
+
+    expect(screen.getByRole('status').textContent).toBe('Toast message');
+
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_TOAST_DURATION - 1);
+    });
+    expect(screen.getByRole('status')).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.queryByRole('status')).toBeNull();
   });
 });

--- a/packages/drawnix/src/components/toast/toast.spec.tsx
+++ b/packages/drawnix/src/components/toast/toast.spec.tsx
@@ -9,14 +9,30 @@ describe('Toast', () => {
     expect(container.textContent).toBe('');
   });
 
-  it('renders toast message and description', () => {
+  it('renders toast message without requiring a description', () => {
     render(
       <Toast
         toast={{
           id: 1,
           type: 'success',
           message: 'Copied selected items as PNG to clipboard',
-          description: '(Light mode)',
+        }}
+      />
+    );
+
+    expect(screen.getByRole('status').textContent).toBe(
+      'Copied selected items as PNG to clipboard'
+    );
+  });
+
+  it('renders optional toast description', () => {
+    render(
+      <Toast
+        toast={{
+          id: 2,
+          type: 'success',
+          message: 'Copied selected items as PNG to clipboard',
+          description: '(Transparent background)',
         }}
       />
     );
@@ -24,6 +40,6 @@ describe('Toast', () => {
     expect(screen.getByRole('status').textContent).toContain(
       'Copied selected items as PNG to clipboard'
     );
-    expect(screen.getByText('(Light mode)')).toBeTruthy();
+    expect(screen.getByText('(Transparent background)')).toBeTruthy();
   });
 });

--- a/packages/drawnix/src/components/toast/toast.spec.tsx
+++ b/packages/drawnix/src/components/toast/toast.spec.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Toast } from './toast';
+
+describe('Toast', () => {
+  it('does not render empty toast content', () => {
+    const { container } = render(<Toast toast={null} />);
+
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders toast message and description', () => {
+    render(
+      <Toast
+        toast={{
+          id: 1,
+          type: 'success',
+          message: 'Copied selected items as PNG to clipboard',
+          description: '(Light mode)',
+        }}
+      />
+    );
+
+    expect(screen.getByRole('status').textContent).toContain(
+      'Copied selected items as PNG to clipboard'
+    );
+    expect(screen.getByText('(Light mode)')).toBeTruthy();
+  });
+});

--- a/packages/drawnix/src/components/toast/toast.tsx
+++ b/packages/drawnix/src/components/toast/toast.tsx
@@ -1,18 +1,74 @@
 import classNames from 'classnames';
-import type { DrawnixToast } from '../../hooks/use-drawnix';
+import { FloatingPortal } from '@floating-ui/react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { DrawnixToast, DrawnixToastOptions } from '../../hooks/use-drawnix';
 import './toast.scss';
 
-export const Toast = ({ toast }: { toast: DrawnixToast | null }) => {
-  if (!toast) {
-    return null;
-  }
+export const DEFAULT_TOAST_DURATION = 4000;
 
+export const useToast = () => {
+  const [toast, setToast] = useState<DrawnixToast | null>(null);
+  const toastIdRef = useRef(0);
+  const toastTimerRef = useRef<number | null>(null);
+
+  const showToast = useCallback((toastOptions: DrawnixToastOptions) => {
+    toastIdRef.current += 1;
+    const id = toastIdRef.current;
+    const duration = toastOptions.duration ?? DEFAULT_TOAST_DURATION;
+
+    if (toastTimerRef.current) {
+      window.clearTimeout(toastTimerRef.current);
+      toastTimerRef.current = null;
+    }
+
+    setToast({
+      id,
+      message: toastOptions.message,
+      description: toastOptions.description,
+      type: toastOptions.type || 'info',
+    });
+
+    if (duration > 0) {
+      toastTimerRef.current = window.setTimeout(() => {
+        setToast((currentToast) => (currentToast?.id === id ? null : currentToast));
+        toastTimerRef.current = null;
+      }, duration);
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) {
+        window.clearTimeout(toastTimerRef.current);
+      }
+    };
+  }, []);
+
+  return { toast, showToast };
+};
+
+export const Toast = ({
+  toast,
+  container,
+}: {
+  toast: DrawnixToast | null;
+  container?: HTMLElement | null;
+}) => {
   return (
-    <div className="drawnix-toast-wrapper" aria-live="polite" aria-atomic="true">
-      <div role="status" className={classNames('drawnix-toast', `drawnix-toast--${toast.type}`)}>
-        <div className="drawnix-toast__message">{toast.message}</div>
-        {toast.description && <div className="drawnix-toast__description">{toast.description}</div>}
-      </div>
-    </div>
+    <FloatingPortal root={container} preserveTabOrder={false}>
+      {toast && (
+        <div className="drawnix-toast-wrapper" aria-live="polite" aria-atomic="true">
+          <div
+            role="status"
+            className={classNames('drawnix-toast', `drawnix-toast--${toast.type}`)}
+          >
+            <div className="drawnix-toast__message">{toast.message}</div>
+            {toast.description && (
+              <div className="drawnix-toast__description">{toast.description}</div>
+            )}
+          </div>
+        </div>
+      )}
+    </FloatingPortal>
   );
 };

--- a/packages/drawnix/src/components/toast/toast.tsx
+++ b/packages/drawnix/src/components/toast/toast.tsx
@@ -1,10 +1,25 @@
 import classNames from 'classnames';
 import { FloatingPortal } from '@floating-ui/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { DrawnixToast, DrawnixToastOptions } from '../../hooks/use-drawnix';
 import './toast.scss';
 
 export const DEFAULT_TOAST_DURATION = 4000;
+
+export type DrawnixToastType = 'info' | 'success' | 'error';
+
+export type DrawnixToastOptions = {
+  message: string;
+  description?: string;
+  type?: DrawnixToastType;
+  duration?: number;
+};
+
+export type DrawnixToast = {
+  id: number;
+  message: string;
+  description?: string;
+  type: DrawnixToastType;
+};
 
 export const useToast = () => {
   const [toast, setToast] = useState<DrawnixToast | null>(null);

--- a/packages/drawnix/src/components/toast/toast.tsx
+++ b/packages/drawnix/src/components/toast/toast.tsx
@@ -1,0 +1,18 @@
+import classNames from 'classnames';
+import type { DrawnixToast } from '../../hooks/use-drawnix';
+import './toast.scss';
+
+export const Toast = ({ toast }: { toast: DrawnixToast | null }) => {
+  if (!toast) {
+    return null;
+  }
+
+  return (
+    <div className="drawnix-toast-wrapper" aria-live="polite" aria-atomic="true">
+      <div role="status" className={classNames('drawnix-toast', `drawnix-toast--${toast.type}`)}>
+        <div className="drawnix-toast__message">{toast.message}</div>
+        {toast.description && <div className="drawnix-toast__description">{toast.description}</div>}
+      </div>
+    </div>
+  );
+};

--- a/packages/drawnix/src/drawnix.tsx
+++ b/packages/drawnix/src/drawnix.tsx
@@ -111,6 +111,9 @@ export const Drawnix: React.FC<DrawnixProps> = ({
   });
 
   const [board, setBoard] = useState<DrawnixBoard | null>(null);
+  const [themeColorMode, setThemeColorMode] = useState<ThemeColorMode>(
+    theme?.themeColorMode || ThemeColorMode.default
+  );
   const [toast, setToast] = useState<DrawnixToast | null>(null);
   const toastIdRef = useRef(0);
   const toastTimerRef = useRef<number | null>(null);
@@ -165,6 +168,12 @@ export const Drawnix: React.FC<DrawnixProps> = ({
     };
   }, []);
 
+  useEffect(() => {
+    if (theme?.themeColorMode) {
+      setThemeColorMode(theme.themeColorMode);
+    }
+  }, [theme?.themeColorMode]);
+
   const updateAppState = (newAppState: Partial<DrawnixState>) => {
     setAppState((currentAppState) => ({
       ...currentAppState,
@@ -208,6 +217,7 @@ export const Drawnix: React.FC<DrawnixProps> = ({
         <div
           className={classNames('drawnix', {
             'drawnix--mobile': appState.isMobile,
+            [`theme--${themeColorMode}`]: themeColorMode,
           })}
           ref={containerRef}
         >
@@ -222,7 +232,10 @@ export const Drawnix: React.FC<DrawnixProps> = ({
             }}
             onSelectionChange={onSelectionChange}
             onViewportChange={onViewportChange}
-            onThemeChange={onThemeChange}
+            onThemeChange={(value) => {
+              setThemeColorMode(value);
+              onThemeChange?.(value);
+            }}
             onValueChange={onValueChange}
           >
             <Board

--- a/packages/drawnix/src/drawnix.tsx
+++ b/packages/drawnix/src/drawnix.tsx
@@ -11,7 +11,7 @@ import {
   ThemeColorMode,
   Viewport,
 } from '@plait/core';
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { BoardCreationMode, setCreationMode, withGroup } from '@plait/common';
 import { withDraw } from '@plait/draw';
 import { MindThemeColors, withMind } from '@plait/mind';
@@ -32,9 +32,11 @@ import { buildPencilPlugin } from './plugins/with-pencil';
 import {
   DrawnixBoard,
   DrawnixContext,
-  DrawnixState,
   DrawnixToolState,
   mergeToolState,
+  type DrawnixState,
+  type DrawnixToast,
+  type DrawnixToastOptions,
 } from './hooks/use-drawnix';
 import { ClosePencilToolbar } from './components/toolbar/pencil-mode-toolbar';
 import { TTDDialog } from './components/ttd-dialog/ttd-dialog';
@@ -44,6 +46,7 @@ import { LinkPopup } from './components/popup/link-popup/link-popup';
 import { I18nProvider } from './i18n';
 import { Tutorial } from './components/tutorial';
 import { LASER_POINTER_CLASS_NAME } from './utils/laser-pointer';
+import { Toast } from './components/toast/toast';
 
 export type DrawnixProps = {
   value: PlaitElement[];
@@ -108,9 +111,38 @@ export const Drawnix: React.FC<DrawnixProps> = ({
   });
 
   const [board, setBoard] = useState<DrawnixBoard | null>(null);
+  const [toast, setToast] = useState<DrawnixToast | null>(null);
+  const toastIdRef = useRef(0);
+  const toastTimerRef = useRef<number | null>(null);
+
+  const showToast = useCallback((toastOptions: DrawnixToastOptions) => {
+    toastIdRef.current += 1;
+    const id = toastIdRef.current;
+    const duration = toastOptions.duration ?? 2500;
+
+    if (toastTimerRef.current) {
+      window.clearTimeout(toastTimerRef.current);
+      toastTimerRef.current = null;
+    }
+
+    setToast({
+      id,
+      message: toastOptions.message,
+      description: toastOptions.description,
+      type: toastOptions.type || 'info',
+    });
+
+    if (duration > 0) {
+      toastTimerRef.current = window.setTimeout(() => {
+        setToast((currentToast) => (currentToast?.id === id ? null : currentToast));
+        toastTimerRef.current = null;
+      }, duration);
+    }
+  }, []);
 
   if (board) {
     board.appState = appState;
+    board.showToast = showToast;
   }
 
   const hasMountedToolStateRef = useRef(false);
@@ -124,6 +156,14 @@ export const Drawnix: React.FC<DrawnixProps> = ({
     }
     onToolStateChangeRef.current?.(appState.toolState);
   }, [appState.toolState]);
+
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) {
+        window.clearTimeout(toastTimerRef.current);
+      }
+    };
+  }, []);
 
   const updateAppState = (newAppState: Partial<DrawnixState>) => {
     setAppState((currentAppState) => ({
@@ -164,7 +204,7 @@ export const Drawnix: React.FC<DrawnixProps> = ({
 
   return (
     <I18nProvider>
-      <DrawnixContext.Provider value={{ appState, setAppState }}>
+      <DrawnixContext.Provider value={{ appState, setAppState, showToast }}>
         <div
           className={classNames('drawnix', {
             'drawnix--mobile': appState.isMobile,
@@ -204,6 +244,7 @@ export const Drawnix: React.FC<DrawnixProps> = ({
             <ClosePencilToolbar></ClosePencilToolbar>
             <TTDDialog container={containerRef.current}></TTDDialog>
             <CleanConfirm container={containerRef.current}></CleanConfirm>
+            <Toast toast={toast}></Toast>
           </Wrapper>
           <canvas className={`${LASER_POINTER_CLASS_NAME} mouse-course-hidden`}></canvas>
         </div>

--- a/packages/drawnix/src/drawnix.tsx
+++ b/packages/drawnix/src/drawnix.tsx
@@ -11,7 +11,7 @@ import {
   ThemeColorMode,
   Viewport,
 } from '@plait/core';
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { BoardCreationMode, setCreationMode, withGroup } from '@plait/common';
 import { withDraw } from '@plait/draw';
 import { MindThemeColors, withMind } from '@plait/mind';
@@ -35,8 +35,6 @@ import {
   DrawnixToolState,
   mergeToolState,
   type DrawnixState,
-  type DrawnixToast,
-  type DrawnixToastOptions,
 } from './hooks/use-drawnix';
 import { ClosePencilToolbar } from './components/toolbar/pencil-mode-toolbar';
 import { TTDDialog } from './components/ttd-dialog/ttd-dialog';
@@ -46,7 +44,7 @@ import { LinkPopup } from './components/popup/link-popup/link-popup';
 import { I18nProvider } from './i18n';
 import { Tutorial } from './components/tutorial';
 import { LASER_POINTER_CLASS_NAME } from './utils/laser-pointer';
-import { Toast } from './components/toast/toast';
+import { Toast, useToast } from './components/toast/toast';
 
 export type DrawnixProps = {
   value: PlaitElement[];
@@ -114,34 +112,7 @@ export const Drawnix: React.FC<DrawnixProps> = ({
   const [themeColorMode, setThemeColorMode] = useState<ThemeColorMode>(
     theme?.themeColorMode || ThemeColorMode.default
   );
-  const [toast, setToast] = useState<DrawnixToast | null>(null);
-  const toastIdRef = useRef(0);
-  const toastTimerRef = useRef<number | null>(null);
-
-  const showToast = useCallback((toastOptions: DrawnixToastOptions) => {
-    toastIdRef.current += 1;
-    const id = toastIdRef.current;
-    const duration = toastOptions.duration ?? 2500;
-
-    if (toastTimerRef.current) {
-      window.clearTimeout(toastTimerRef.current);
-      toastTimerRef.current = null;
-    }
-
-    setToast({
-      id,
-      message: toastOptions.message,
-      description: toastOptions.description,
-      type: toastOptions.type || 'info',
-    });
-
-    if (duration > 0) {
-      toastTimerRef.current = window.setTimeout(() => {
-        setToast((currentToast) => (currentToast?.id === id ? null : currentToast));
-        toastTimerRef.current = null;
-      }, duration);
-    }
-  }, []);
+  const { toast, showToast } = useToast();
 
   if (board) {
     board.appState = appState;
@@ -159,14 +130,6 @@ export const Drawnix: React.FC<DrawnixProps> = ({
     }
     onToolStateChangeRef.current?.(appState.toolState);
   }, [appState.toolState]);
-
-  useEffect(() => {
-    return () => {
-      if (toastTimerRef.current) {
-        window.clearTimeout(toastTimerRef.current);
-      }
-    };
-  }, []);
 
   useEffect(() => {
     if (theme?.themeColorMode) {
@@ -257,7 +220,7 @@ export const Drawnix: React.FC<DrawnixProps> = ({
             <ClosePencilToolbar></ClosePencilToolbar>
             <TTDDialog container={containerRef.current}></TTDDialog>
             <CleanConfirm container={containerRef.current}></CleanConfirm>
-            <Toast toast={toast}></Toast>
+            <Toast toast={toast} container={containerRef.current}></Toast>
           </Wrapper>
           <canvas className={`${LASER_POINTER_CLASS_NAME} mouse-course-hidden`}></canvas>
         </div>

--- a/packages/drawnix/src/hooks/use-drawnix.tsx
+++ b/packages/drawnix/src/hooks/use-drawnix.tsx
@@ -58,7 +58,24 @@ export const mergeToolState = (toolState?: Partial<DrawnixToolState>): DrawnixTo
 
 export interface DrawnixBoard extends PlaitBoard {
   appState: DrawnixState;
+  showToast?: (toast: DrawnixToastOptions) => void;
 }
+
+export type DrawnixToastType = 'info' | 'success' | 'error';
+
+export type DrawnixToastOptions = {
+  message: string;
+  description?: string;
+  type?: DrawnixToastType;
+  duration?: number;
+};
+
+export type DrawnixToast = {
+  id: number;
+  message: string;
+  description?: string;
+  type: DrawnixToastType;
+};
 
 export type LinkState = {
   targetDom: HTMLElement;
@@ -84,11 +101,13 @@ export type DrawnixState = {
 export const DrawnixContext = createContext<{
   appState: DrawnixState;
   setAppState: Dispatch<SetStateAction<DrawnixState>>;
+  showToast: (toast: DrawnixToastOptions) => void;
 } | null>(null);
 
 export const useDrawnix = (): {
   appState: DrawnixState;
   setAppState: Dispatch<SetStateAction<DrawnixState>>;
+  showToast: (toast: DrawnixToastOptions) => void;
 } => {
   const context = useContext(DrawnixContext);
 

--- a/packages/drawnix/src/hooks/use-drawnix.tsx
+++ b/packages/drawnix/src/hooks/use-drawnix.tsx
@@ -11,6 +11,7 @@ import { Editor } from 'slate';
 import { LinkElement } from '@plait/common';
 import { DEFAULT_FREEHAND_PRESETS, FreehandDrawOptions } from '../plugins/freehand/presets';
 import { DrawnixFileHandle } from '../data/json';
+import type { DrawnixToastOptions } from '../components/toast/toast';
 
 export enum DialogType {
   mermaidToDrawnix = 'mermaidToDrawnix',
@@ -60,22 +61,6 @@ export interface DrawnixBoard extends PlaitBoard {
   appState: DrawnixState;
   showToast?: (toast: DrawnixToastOptions) => void;
 }
-
-export type DrawnixToastType = 'info' | 'success' | 'error';
-
-export type DrawnixToastOptions = {
-  message: string;
-  description?: string;
-  type?: DrawnixToastType;
-  duration?: number;
-};
-
-export type DrawnixToast = {
-  id: number;
-  message: string;
-  description?: string;
-  type: DrawnixToastType;
-};
 
 export type LinkState = {
   targetDom: HTMLElement;

--- a/packages/drawnix/src/i18n/translations/ar.ts
+++ b/packages/drawnix/src/i18n/translations/ar.ts
@@ -78,6 +78,10 @@ const arTranslations: Translations = {
   'general.copyToClipboard.svg': 'SVG',
   'general.copyToClipboard.png': 'PNG',
   'general.copyToClipboard.transparent': 'خلفية شفافة',
+  'toast.copyToClipboard.svg': 'تم نسخ العناصر المحددة كـ SVG إلى الحافظة',
+  'toast.copyToClipboard.png': 'تم نسخ العناصر المحددة كـ PNG إلى الحافظة',
+  'toast.copyToClipboard.mode.light': '(الوضع الفاتح)',
+  'toast.copyToClipboard.mode.transparent': '(خلفية شفافة)',
 
   // Menu items
   'menu.open': 'فتح',

--- a/packages/drawnix/src/i18n/translations/ar.ts
+++ b/packages/drawnix/src/i18n/translations/ar.ts
@@ -80,7 +80,6 @@ const arTranslations: Translations = {
   'general.copyToClipboard.transparent': 'خلفية شفافة',
   'toast.copyToClipboard.svg': 'تم نسخ العناصر المحددة كـ SVG إلى الحافظة',
   'toast.copyToClipboard.png': 'تم نسخ العناصر المحددة كـ PNG إلى الحافظة',
-  'toast.copyToClipboard.mode.light': '(الوضع الفاتح)',
   'toast.copyToClipboard.mode.transparent': '(خلفية شفافة)',
 
   // Menu items

--- a/packages/drawnix/src/i18n/translations/en.ts
+++ b/packages/drawnix/src/i18n/translations/en.ts
@@ -73,7 +73,6 @@ const enTranslations: Translations = {
   'general.copyToClipboard.transparent': 'Transparent',
   'toast.copyToClipboard.svg': 'Copied selected items as SVG to clipboard',
   'toast.copyToClipboard.png': 'Copied selected items as PNG to clipboard',
-  'toast.copyToClipboard.mode.light': '(Light mode)',
   'toast.copyToClipboard.mode.transparent': '(Transparent background)',
   // Language
   'language.switcher': 'Language',

--- a/packages/drawnix/src/i18n/translations/en.ts
+++ b/packages/drawnix/src/i18n/translations/en.ts
@@ -71,6 +71,10 @@ const enTranslations: Translations = {
   'general.copyToClipboard.svg': 'SVG',
   'general.copyToClipboard.png': 'PNG',
   'general.copyToClipboard.transparent': 'Transparent',
+  'toast.copyToClipboard.svg': 'Copied selected items as SVG to clipboard',
+  'toast.copyToClipboard.png': 'Copied selected items as PNG to clipboard',
+  'toast.copyToClipboard.mode.light': '(Light mode)',
+  'toast.copyToClipboard.mode.transparent': '(Transparent background)',
   // Language
   'language.switcher': 'Language',
   'language.chinese': '中文',

--- a/packages/drawnix/src/i18n/translations/ru.ts
+++ b/packages/drawnix/src/i18n/translations/ru.ts
@@ -72,6 +72,10 @@ const ruTranslations: Translations = {
   'general.copyToClipboard.svg': 'SVG',
   'general.copyToClipboard.png': 'PNG',
   'general.copyToClipboard.transparent': 'Прозрачный фон',
+  'toast.copyToClipboard.svg': 'Выбранные элементы скопированы в буфер обмена как SVG',
+  'toast.copyToClipboard.png': 'Выбранные элементы скопированы в буфер обмена как PNG',
+  'toast.copyToClipboard.mode.light': '(Светлый режим)',
+  'toast.copyToClipboard.mode.transparent': '(Прозрачный фон)',
   // Language
   'language.switcher': 'Language',
   'language.chinese': '中文',

--- a/packages/drawnix/src/i18n/translations/ru.ts
+++ b/packages/drawnix/src/i18n/translations/ru.ts
@@ -74,7 +74,6 @@ const ruTranslations: Translations = {
   'general.copyToClipboard.transparent': 'Прозрачный фон',
   'toast.copyToClipboard.svg': 'Выбранные элементы скопированы в буфер обмена как SVG',
   'toast.copyToClipboard.png': 'Выбранные элементы скопированы в буфер обмена как PNG',
-  'toast.copyToClipboard.mode.light': '(Светлый режим)',
   'toast.copyToClipboard.mode.transparent': '(Прозрачный фон)',
   // Language
   'language.switcher': 'Language',

--- a/packages/drawnix/src/i18n/translations/vi.ts
+++ b/packages/drawnix/src/i18n/translations/vi.ts
@@ -74,7 +74,6 @@ const viTranslations: Translations = {
   'general.copyToClipboard.transparent': 'Nền trong suốt',
   'toast.copyToClipboard.svg': 'Đã sao chép các mục đã chọn dưới dạng SVG vào bộ nhớ tạm',
   'toast.copyToClipboard.png': 'Đã sao chép các mục đã chọn dưới dạng PNG vào bộ nhớ tạm',
-  'toast.copyToClipboard.mode.light': '(Chế độ sáng)',
   'toast.copyToClipboard.mode.transparent': '(Nền trong suốt)',
   // Language
   'language.switcher': 'Ngôn ngữ',

--- a/packages/drawnix/src/i18n/translations/vi.ts
+++ b/packages/drawnix/src/i18n/translations/vi.ts
@@ -72,6 +72,10 @@ const viTranslations: Translations = {
   'general.copyToClipboard.svg': 'SVG',
   'general.copyToClipboard.png': 'PNG',
   'general.copyToClipboard.transparent': 'Nền trong suốt',
+  'toast.copyToClipboard.svg': 'Đã sao chép các mục đã chọn dưới dạng SVG vào bộ nhớ tạm',
+  'toast.copyToClipboard.png': 'Đã sao chép các mục đã chọn dưới dạng PNG vào bộ nhớ tạm',
+  'toast.copyToClipboard.mode.light': '(Chế độ sáng)',
+  'toast.copyToClipboard.mode.transparent': '(Nền trong suốt)',
   // Language
   'language.switcher': 'Ngôn ngữ',
   'language.chinese': '中文',

--- a/packages/drawnix/src/i18n/translations/zh.ts
+++ b/packages/drawnix/src/i18n/translations/zh.ts
@@ -72,6 +72,10 @@ const zhTranslations: Translations = {
   'general.copyToClipboard.svg': 'SVG',
   'general.copyToClipboard.png': 'PNG',
   'general.copyToClipboard.transparent': '透明背景',
+  'toast.copyToClipboard.svg': '已将所选项作为 SVG 复制到剪贴板',
+  'toast.copyToClipboard.png': '已将所选项作为 PNG 复制到剪贴板',
+  'toast.copyToClipboard.mode.light': '（浅色模式）',
+  'toast.copyToClipboard.mode.transparent': '（透明背景）',
 
   // Language
   'language.switcher': 'Language',

--- a/packages/drawnix/src/i18n/translations/zh.ts
+++ b/packages/drawnix/src/i18n/translations/zh.ts
@@ -74,7 +74,6 @@ const zhTranslations: Translations = {
   'general.copyToClipboard.transparent': '透明背景',
   'toast.copyToClipboard.svg': '已将所选项作为 SVG 复制到剪贴板',
   'toast.copyToClipboard.png': '已将所选项作为 PNG 复制到剪贴板',
-  'toast.copyToClipboard.mode.light': '（浅色模式）',
   'toast.copyToClipboard.mode.transparent': '（透明背景）',
 
   // Language

--- a/packages/drawnix/src/i18n/types.ts
+++ b/packages/drawnix/src/i18n/types.ts
@@ -75,6 +75,10 @@ export interface Translations {
   'general.copyToClipboard.svg': string;
   'general.copyToClipboard.png': string;
   'general.copyToClipboard.transparent': string;
+  'toast.copyToClipboard.svg': string;
+  'toast.copyToClipboard.png': string;
+  'toast.copyToClipboard.mode.light': string;
+  'toast.copyToClipboard.mode.transparent': string;
 
   // Language
   'language.switcher': string;

--- a/packages/drawnix/src/i18n/types.ts
+++ b/packages/drawnix/src/i18n/types.ts
@@ -77,7 +77,6 @@ export interface Translations {
   'general.copyToClipboard.transparent': string;
   'toast.copyToClipboard.svg': string;
   'toast.copyToClipboard.png': string;
-  'toast.copyToClipboard.mode.light': string;
   'toast.copyToClipboard.mode.transparent': string;
 
   // Language

--- a/packages/drawnix/src/utils/image.ts
+++ b/packages/drawnix/src/utils/image.ts
@@ -6,6 +6,7 @@ import { insertImage } from '../data/image';
 import { getBackgroundColor } from './color';
 import { TRANSPARENT } from '../constants/color';
 import type { DrawnixBoard } from '../hooks/use-drawnix';
+import { i18nInsidePlaitHook, type Translations } from '../i18n';
 
 type ClipboardImageFormat = 'svg' | 'png';
 type ExportElements = ReturnType<typeof getSelectedElements>;
@@ -13,6 +14,11 @@ type ExportElements = ReturnType<typeof getSelectedElements>;
 const CLIPBOARD_MIME_TYPES: Record<ClipboardImageFormat, string> = {
   svg: 'image/svg+xml',
   png: 'image/png',
+};
+
+const COPY_TOAST_KEYS: Record<ClipboardImageFormat, keyof Translations> = {
+  svg: 'toast.copyToClipboard.svg',
+  png: 'toast.copyToClipboard.png',
 };
 
 const hasClipboardWriteSupport = () => {
@@ -55,6 +61,23 @@ const writeBlobToClipboard = async (
     item[CLIPBOARD_MIME_TYPES.png] = fallbackPngBlob;
   }
   await navigator.clipboard.write([new ClipboardItem(item)]);
+};
+
+const showCopySuccessToast = (
+  board: PlaitBoard,
+  format: ClipboardImageFormat,
+  isTransparent: boolean
+) => {
+  const { t } = i18nInsidePlaitHook();
+  const modeKey: keyof Translations = isTransparent
+    ? 'toast.copyToClipboard.mode.transparent'
+    : 'toast.copyToClipboard.mode.light';
+
+  (board as DrawnixBoard).showToast?.({
+    type: 'success',
+    message: t(COPY_TOAST_KEYS[format]),
+    description: t(modeKey),
+  });
 };
 
 const getSvgBlob = async (board: PlaitBoard, isTransparent: boolean, elements?: ExportElements) => {
@@ -124,6 +147,7 @@ export const copySelectionAsSvg = async (board: PlaitBoard) => {
     getImageBlob(board, copyTransparent, selectedElements),
   ]);
   await writeBlobToClipboard('svg', blob, pngBlob);
+  showCopySuccessToast(board, 'svg', copyTransparent);
 };
 
 export const copySelectionAsPng = async (board: PlaitBoard) => {
@@ -139,6 +163,7 @@ export const copySelectionAsPng = async (board: PlaitBoard) => {
   // The clipboard only gets image/png. The background choice is controlled by
   // how the image is rendered before writing to the clipboard.
   await writeBlobToClipboard('png', imageBlob);
+  showCopySuccessToast(board, 'png', copyTransparent);
 };
 
 export const addImage = async (board: PlaitBoard) => {

--- a/packages/drawnix/src/utils/image.ts
+++ b/packages/drawnix/src/utils/image.ts
@@ -69,14 +69,11 @@ const showCopySuccessToast = (
   isTransparent: boolean
 ) => {
   const { t } = i18nInsidePlaitHook();
-  const modeKey: keyof Translations = isTransparent
-    ? 'toast.copyToClipboard.mode.transparent'
-    : 'toast.copyToClipboard.mode.light';
 
   (board as DrawnixBoard).showToast?.({
     type: 'success',
     message: t(COPY_TOAST_KEYS[format]),
-    description: t(modeKey),
+    description: isTransparent ? t('toast.copyToClipboard.mode.transparent') : undefined,
   });
 };
 


### PR DESCRIPTION
## Summary

Closes #430.

This PR adds a Drawnix-wide toast mechanism and wires it into successful clipboard copy flows.

- Added a reusable `Toast` UI component rendered from the `Drawnix` root.
- Added a global `showToast` channel exposed through both `DrawnixContext` and `DrawnixBoard`.
- Show a success toast after copying selected content as SVG or PNG.
- Kept default copy success feedback to a compact one-line message; transparent-background copy adds a small secondary line.
- Added localized copy-success toast strings.
- Refined toast styling to match the existing island/menu UI radius and spacing, with theme-aware colors for default, colorful, soft, retro, dark, and starry themes.

## Architecture

The toast lifecycle is centralized in `Drawnix` instead of being owned by individual features. `Drawnix` manages the current toast state, auto-dismiss timer, and root-level rendering, while feature code only calls `showToast({ message, description, type, duration })`.

There are two access paths for future features:

- React UI can use `useDrawnix().showToast` from context.
- Board/plugin utility code can call `board.showToast`, which is useful for non-React flows such as clipboard, export, import, save, or hotkey handlers.

This keeps later notification work cheap: new success/error/info tips can reuse the same component, theme handling, timer cleanup, accessibility semantics, and placement without creating one-off DOM overlays. The payload is intentionally small today, but the structure can grow later if we need queued toasts, actions, icons, or richer variants.

## Validation

- `npx oxfmt --check ...`
- `npx vitest run --config packages/drawnix/vite.config.ts`
- `npx vite build --config packages/drawnix/vite.config.ts`
- `npx oxlint`

Note: build/test still report the existing package exports warning about `packages/drawnix/package.json` `types` condition ordering; this PR does not change that package metadata.