### PR TITLE
fix(drawnix): preserve text color in exports

### DIFF
--- a/packages/drawnix/src/utils/common.spec.ts
+++ b/packages/drawnix/src/utils/common.spec.ts
@@ -1,0 +1,25 @@
+import { toImage } from '@plait/core';
+import { describe, expect, it, vi } from 'vitest';
+import { boardToImage } from './common';
+
+vi.mock('@plait/core', () => ({
+  IS_APPLE: false,
+  IS_MAC: false,
+  toImage: vi.fn(),
+}));
+
+describe('boardToImage', () => {
+  it('inlines Slate text color styles for exports', () => {
+    const board = {} as any;
+
+    boardToImage(board);
+
+    expect(toImage).toHaveBeenCalledWith(
+      board,
+      expect.objectContaining({
+        inlineStyleClassNames: expect.stringContaining('[data-slate-leaf]'),
+        styleNames: expect.arrayContaining(['color']),
+      })
+    );
+  });
+});

--- a/packages/drawnix/src/utils/common.ts
+++ b/packages/drawnix/src/utils/common.ts
@@ -45,7 +45,8 @@ export const base64ToBlob = (base64: string) => {
 export const boardToImage = (board: PlaitBoard, options: ToImageOptions = {}) => {
   return toImage(board, {
     fillStyle: 'transparent',
-    inlineStyleClassNames: '.extend,.emojis,.text',
+    inlineStyleClassNames: '.extend,.emojis,.text,[data-slate-node="text"],[data-slate-leaf]',
+    styleNames: ['color'],
     padding: 20,
     ratio: 4,
     ...options,

--- a/packages/drawnix/src/utils/image.ts
+++ b/packages/drawnix/src/utils/image.ts
@@ -15,6 +15,9 @@ const CLIPBOARD_MIME_TYPES: Record<ClipboardImageFormat, string> = {
   png: 'image/png',
 };
 
+const EXPORT_INLINE_STYLE_SELECTOR =
+  '.plait-text-container,[data-slate-node="text"],[data-slate-leaf]';
+
 const hasClipboardWriteSupport = () => {
   // Keep the ClipboardItem check local until the shared helper also covers it.
   return (
@@ -65,8 +68,8 @@ const getSvgBlob = async (board: PlaitBoard, isTransparent: boolean, elements?: 
     padding: 20,
     ratio: 4,
     elements,
-    inlineStyleClassNames: '.plait-text-container',
-    styleNames: ['position'],
+    inlineStyleClassNames: EXPORT_INLINE_STYLE_SELECTOR,
+    styleNames: ['position', 'color'],
   });
   return new Blob([svgData], { type: CLIPBOARD_MIME_TYPES.svg });
 };


### PR DESCRIPTION
## Summary

Closes #424.

This PR fixes text color loss when exporting the board as PNG or SVG.

## Root Cause

Drawnix renders rich text through Slate inside SVG `foreignObject`s. Text color is available on the live board through computed DOM styles, but the export path clones the board DOM into a standalone SVG and only preserves a small allowlist of computed styles.

`@plait/core` already preserves text styles such as font size, font family, line height, decoration, weight, and style, but `color` was not included for the Drawnix export paths. Once the cloned SVG is detached from the live page/theme context, text can fall back to the browser default color. PNG export is affected as well because it renders from the generated SVG into a canvas.

## What Changed

- Include Slate text nodes/leaves in the export inline-style selector.
- Add `color` to the export style allowlist for SVG export.
- Add the same `color` preservation to the PNG path through `boardToImage`.
- Add a regression test that verifies `boardToImage` passes Slate leaf selection and `color` style preservation into `toImage`.

## Why This Shape

This is intentionally a small app-side fix. It keeps normal board rendering unchanged and only makes exported SVG/PNG output self-contained for text color. The added `color` value is a CSS property allowlist entry for export cloning, not a new theme variable or rendering state.

## Validation

- `npx oxfmt --check packages/drawnix/src/utils/common.ts packages/drawnix/src/utils/image.ts packages/drawnix/src/utils/common.spec.ts`
- `npx vitest run --config packages/drawnix/vite.config.ts`
- `npx vite build --config packages/drawnix/vite.config.ts`
- `npx oxlint`

Note: build/test still report the existing package exports warning about `packages/drawnix/package.json` `types` condition ordering; this PR does not change that package metadata.

<img width="912" height="576" alt="image" src="https://github.com/user-attachments/assets/0300eb3f-1205-4593-9e90-b3f51d5e6788" />
