### PR TITLE
feat(preference): persist language and copy/export transparency

### DIFF
--- a/apps/web/src/app/app.tsx
+++ b/apps/web/src/app/app.tsx
@@ -9,8 +9,17 @@ type AppValue = {
   theme?: PlaitTheme;
 };
 
+type Language = 'zh' | 'en' | 'ru' | 'ar' | 'vi';
+
+type MainBoardPreference = {
+  language: Language;
+  copyTransparent: boolean;
+  exportTransparent: boolean;
+};
+
 const MAIN_BOARD_CONTENT_KEY = 'main_board_content';
 const MAIN_BOARD_TOOL_STATE_KEY = 'main_board_tool_state';
+const MAIN_BOARD_PREFERENCE_KEY = 'main_board_preference';
 
 localforage.config({
   name: 'Drawnix',
@@ -21,15 +30,29 @@ localforage.config({
 export function App() {
   const [value, setValue] = useState<AppValue>({ children: [] });
   const [initialToolState, setInitialToolState] = useState<Partial<DrawnixToolState>>();
+  const [preference, setPreference] = useState<MainBoardPreference>({
+    language: 'zh',
+    copyTransparent: false,
+    exportTransparent: false,
+  });
   const [loaded, setLoaded] = useState(false);
 
   const [tutorial, setTutorial] = useState(false);
 
+  const updatePreference = (partialPreference: Partial<MainBoardPreference>) => {
+    setPreference((currentPreference) => {
+      const nextPreference = { ...currentPreference, ...partialPreference };
+      localforage.setItem(MAIN_BOARD_PREFERENCE_KEY, nextPreference);
+      return nextPreference;
+    });
+  };
+
   useEffect(() => {
     const loadData = async () => {
-      const [storedData, storedToolState] = await Promise.all([
+      const [storedData, storedToolState, storedPreference] = await Promise.all([
         localforage.getItem(MAIN_BOARD_CONTENT_KEY),
         localforage.getItem(MAIN_BOARD_TOOL_STATE_KEY),
+        localforage.getItem(MAIN_BOARD_PREFERENCE_KEY),
       ]);
       if (storedData) {
         const appValue = storedData as AppValue;
@@ -42,6 +65,9 @@ export function App() {
       }
       if (storedToolState) {
         setInitialToolState(storedToolState as Partial<DrawnixToolState>);
+      }
+      if (storedPreference) {
+        setPreference(storedPreference as MainBoardPreference);
       }
       setLoaded(true);
     };
@@ -56,6 +82,17 @@ export function App() {
       viewport={value.viewport}
       theme={value.theme}
       initialToolState={initialToolState}
+      initialLanguage={preference.language}
+      initialPreference={{
+        copyTransparent: preference.copyTransparent,
+        exportTransparent: preference.exportTransparent,
+      }}
+      onLanguageChange={(language) => {
+        updatePreference({ language });
+      }}
+      onPreferenceChange={({ copyTransparent, exportTransparent }) => {
+        updatePreference({ copyTransparent, exportTransparent });
+      }}
       onChange={(value) => {
         const newValue = value as AppValue;
         localforage.setItem(MAIN_BOARD_CONTENT_KEY, newValue);

--- a/packages/drawnix/src/drawnix.tsx
+++ b/packages/drawnix/src/drawnix.tsx
@@ -63,7 +63,10 @@ export type DrawnixProps = {
   onViewportChange?: (value: Viewport) => void;
   onThemeChange?: (value: ThemeColorMode) => void;
   onToolStateChange?: (toolState: DrawnixToolState) => void;
-  onPreferenceChange?: (preference: { copyTransparent: boolean; exportTransparent: boolean }) => void;
+  onPreferenceChange?: (preference: {
+    copyTransparent: boolean;
+    exportTransparent: boolean;
+  }) => void;
   onLanguageChange?: (language: Language) => void;
   afterInit?: (board: PlaitBoard) => void;
   tutorial?: boolean;

--- a/packages/drawnix/src/drawnix.tsx
+++ b/packages/drawnix/src/drawnix.tsx
@@ -41,7 +41,8 @@ import { TTDDialog } from './components/ttd-dialog/ttd-dialog';
 import { CleanConfirm } from './components/clean-confirm/clean-confirm';
 import { buildTextLinkPlugin } from './plugins/with-text-link';
 import { LinkPopup } from './components/popup/link-popup/link-popup';
-import { I18nProvider } from './i18n';
+import { I18nProvider, setBoardLanguage } from './i18n';
+import type { Language } from './i18n/types';
 import { Tutorial } from './components/tutorial';
 import { LASER_POINTER_CLASS_NAME } from './utils/laser-pointer';
 import { Toast, useToast } from './components/toast/toast';
@@ -51,12 +52,19 @@ export type DrawnixProps = {
   viewport?: Viewport;
   theme?: PlaitTheme;
   initialToolState?: Partial<DrawnixToolState>;
+  initialPreference?: {
+    copyTransparent?: boolean;
+    exportTransparent?: boolean;
+  };
+  initialLanguage?: Language;
   onChange?: (value: BoardChangeData) => void;
   onSelectionChange?: (selection: Selection | null) => void;
   onValueChange?: (value: PlaitElement[]) => void;
   onViewportChange?: (value: Viewport) => void;
   onThemeChange?: (value: ThemeColorMode) => void;
   onToolStateChange?: (toolState: DrawnixToolState) => void;
+  onPreferenceChange?: (preference: { copyTransparent: boolean; exportTransparent: boolean }) => void;
+  onLanguageChange?: (language: Language) => void;
   afterInit?: (board: PlaitBoard) => void;
   tutorial?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>;
@@ -78,12 +86,16 @@ export const Drawnix: React.FC<DrawnixProps> = ({
   viewport,
   theme,
   initialToolState,
+  initialPreference,
+  initialLanguage,
   onChange,
   onSelectionChange,
   onViewportChange,
   onThemeChange,
   onValueChange,
   onToolStateChange,
+  onPreferenceChange,
+  onLanguageChange,
   afterInit,
   tutorial = false,
 }) => {
@@ -103,8 +115,8 @@ export const Drawnix: React.FC<DrawnixProps> = ({
       fileHandle: null,
       openDialogType: null,
       openCleanConfirm: false,
-      copyTransparent: false,
-      exportTransparent: false,
+      copyTransparent: initialPreference?.copyTransparent ?? false,
+      exportTransparent: initialPreference?.exportTransparent ?? false,
     };
   });
 
@@ -113,11 +125,19 @@ export const Drawnix: React.FC<DrawnixProps> = ({
     theme?.themeColorMode || ThemeColorMode.default
   );
   const { toast, showToast } = useToast();
+  const lastKnownLanguageRef = useRef<Language>(initialLanguage ?? 'zh');
 
   if (board) {
     board.appState = appState;
     board.showToast = showToast;
   }
+
+  useEffect(() => {
+    if (!board) {
+      return;
+    }
+    setBoardLanguage(board, lastKnownLanguageRef.current);
+  }, [board]);
 
   const hasMountedToolStateRef = useRef(false);
   const onToolStateChangeRef = useRef(onToolStateChange);
@@ -130,6 +150,21 @@ export const Drawnix: React.FC<DrawnixProps> = ({
     }
     onToolStateChangeRef.current?.(appState.toolState);
   }, [appState.toolState]);
+
+  const hasMountedPreferenceRef = useRef(false);
+  const onPreferenceChangeRef = useRef(onPreferenceChange);
+  onPreferenceChangeRef.current = onPreferenceChange;
+
+  useEffect(() => {
+    if (!hasMountedPreferenceRef.current) {
+      hasMountedPreferenceRef.current = true;
+      return;
+    }
+    onPreferenceChangeRef.current?.({
+      copyTransparent: appState.copyTransparent,
+      exportTransparent: appState.exportTransparent,
+    });
+  }, [appState.copyTransparent, appState.exportTransparent]);
 
   useEffect(() => {
     if (theme?.themeColorMode) {
@@ -175,7 +210,16 @@ export const Drawnix: React.FC<DrawnixProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
 
   return (
-    <I18nProvider>
+    <I18nProvider
+      initialLanguage={initialLanguage}
+      onLanguageChange={(language) => {
+        lastKnownLanguageRef.current = language;
+        if (board) {
+          setBoardLanguage(board, language);
+        }
+        onLanguageChange?.(language);
+      }}
+    >
       <DrawnixContext.Provider value={{ appState, setAppState, showToast }}>
         <div
           className={classNames('drawnix', {

--- a/packages/drawnix/src/i18n.tsx
+++ b/packages/drawnix/src/i18n.tsx
@@ -1,2 +1,2 @@
-export { I18nProvider, useI18n, i18nInsidePlaitHook } from './i18n/index';
+export { I18nProvider, useI18n, i18nInsidePlaitHook, setBoardLanguage } from './i18n/index';
 export type { Language, Translations, I18nContextType } from './i18n/types';

--- a/packages/drawnix/src/i18n/index.spec.ts
+++ b/packages/drawnix/src/i18n/index.spec.ts
@@ -24,4 +24,3 @@ describe('i18nInsidePlaitHook', () => {
     expect(t('general.delete')).toBe('Delete');
   });
 });
-

--- a/packages/drawnix/src/i18n/index.spec.ts
+++ b/packages/drawnix/src/i18n/index.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { i18nInsidePlaitHook, setBoardLanguage } from './index';
+
+describe('i18nInsidePlaitHook', () => {
+  it('resolves language dynamically for a board instance', () => {
+    const board = {};
+    const i18n = i18nInsidePlaitHook(board);
+
+    expect(i18n.language).toBe('zh');
+    expect(i18n.t('general.delete')).toBe('删除');
+
+    setBoardLanguage(board, 'en');
+
+    expect(i18n.language).toBe('en');
+    expect(i18n.t('general.delete')).toBe('Delete');
+  });
+
+  it('keeps the returned t() up-to-date even if the language is set after initialization', () => {
+    const board = {};
+    const { t } = i18nInsidePlaitHook(board);
+
+    setBoardLanguage(board, 'en');
+
+    expect(t('general.delete')).toBe('Delete');
+  });
+});
+

--- a/packages/drawnix/src/i18n/index.tsx
+++ b/packages/drawnix/src/i18n/index.tsx
@@ -8,6 +8,9 @@ import {
 } from './translations';
 import { Language, Translations, I18nContextType, I18nProviderProps } from './types';
 
+const DEFAULT_LANGUAGE: Language = 'zh';
+const boardLanguageMap = new WeakMap<object, Language>();
+
 // Translation data
 const translations: Record<Language, Translations> = {
   zh: zhTranslations,
@@ -20,16 +23,25 @@ const translations: Record<Language, Translations> = {
 // Create the context
 const I18nContext = createContext<I18nContextType | undefined>(undefined);
 
-export const I18nProvider: React.FC<I18nProviderProps> = ({ children, defaultLanguage = 'zh' }) => {
+export const setBoardLanguage = (board: object, language: Language) => {
+  boardLanguageMap.set(board, language);
+};
+
+export const I18nProvider: React.FC<I18nProviderProps> = ({
+  children,
+  defaultLanguage = DEFAULT_LANGUAGE,
+  initialLanguage,
+  onLanguageChange,
+}) => {
   const [language, setLanguageState] = useState<Language>(() => {
-    const storedLanguage = localStorage.getItem('language') as Language;
-    return storedLanguage || defaultLanguage;
+    const initial = initialLanguage ?? defaultLanguage;
+    return initial;
   });
 
   const setLanguage = useCallback((newLanguage: Language) => {
-    localStorage.setItem('language', newLanguage);
     setLanguageState(newLanguage);
-  }, []);
+    onLanguageChange?.(newLanguage);
+  }, [onLanguageChange]);
 
   const t = useCallback(
     (key: keyof Translations): string => {
@@ -60,13 +72,13 @@ export const useI18n = (): I18nContextType => {
   return context;
 };
 
-export const i18nInsidePlaitHook = () => {
+export const i18nInsidePlaitHook = (board?: object | null) => {
+  const resolvedLanguage = (board ? boardLanguageMap.get(board) : undefined) ?? DEFAULT_LANGUAGE;
   const i18n = {
     t: (key: keyof Translations): string => {
-      const currentLang = (localStorage.getItem('language') as Language) || 'zh';
-      return translations[currentLang][key] || key;
+      return translations[resolvedLanguage][key] || key;
     },
-    language: (localStorage.getItem('language') as Language) || 'zh',
+    language: resolvedLanguage,
   };
 
   return i18n;

--- a/packages/drawnix/src/i18n/index.tsx
+++ b/packages/drawnix/src/i18n/index.tsx
@@ -76,12 +76,17 @@ export const useI18n = (): I18nContextType => {
 };
 
 export const i18nInsidePlaitHook = (board?: object | null) => {
-  const resolvedLanguage = (board ? boardLanguageMap.get(board) : undefined) ?? DEFAULT_LANGUAGE;
+  const resolveLanguage = () => {
+    return (board ? boardLanguageMap.get(board) : undefined) ?? DEFAULT_LANGUAGE;
+  };
   const i18n = {
     t: (key: keyof Translations): string => {
+      const resolvedLanguage = resolveLanguage();
       return translations[resolvedLanguage][key] || key;
     },
-    language: resolvedLanguage,
+    get language(): Language {
+      return resolveLanguage();
+    },
   };
 
   return i18n;

--- a/packages/drawnix/src/i18n/index.tsx
+++ b/packages/drawnix/src/i18n/index.tsx
@@ -38,10 +38,13 @@ export const I18nProvider: React.FC<I18nProviderProps> = ({
     return initial;
   });
 
-  const setLanguage = useCallback((newLanguage: Language) => {
-    setLanguageState(newLanguage);
-    onLanguageChange?.(newLanguage);
-  }, [onLanguageChange]);
+  const setLanguage = useCallback(
+    (newLanguage: Language) => {
+      setLanguageState(newLanguage);
+      onLanguageChange?.(newLanguage);
+    },
+    [onLanguageChange]
+  );
 
   const t = useCallback(
     (key: keyof Translations): string => {

--- a/packages/drawnix/src/i18n/types.ts
+++ b/packages/drawnix/src/i18n/types.ts
@@ -182,4 +182,6 @@ export interface I18nContextType {
 export interface I18nProviderProps {
   children: ReactNode;
   defaultLanguage?: Language;
+  initialLanguage?: Language;
+  onLanguageChange?: (language: Language) => void;
 }

--- a/packages/drawnix/src/plugins/with-common.tsx
+++ b/packages/drawnix/src/plugins/with-common.tsx
@@ -27,7 +27,7 @@ export const withCommonPlugin = (board: PlaitBoard) => {
     return ref;
   };
 
-  const { t } = i18nInsidePlaitHook();
+  const { t } = i18nInsidePlaitHook(board);
 
   newBoard.getI18nValue = (key: string) => {
     if (key === DrawI18nKey.lineText) {

--- a/packages/drawnix/src/utils/image.ts
+++ b/packages/drawnix/src/utils/image.ts
@@ -68,7 +68,7 @@ const showCopySuccessToast = (
   format: ClipboardImageFormat,
   isTransparent: boolean
 ) => {
-  const { t } = i18nInsidePlaitHook();
+  const { t } = i18nInsidePlaitHook(board);
 
   (board as DrawnixBoard).showToast?.({
     type: 'success',


### PR DESCRIPTION
- Persist user preference (language, copyTransparent, exportTransparent) via a single localforage key in the web app
- Make the package side stateless: inject initial values via props and notify host via callbacks
- Avoid global language state by mapping language per board instance (WeakMap), so multiple boards won't conflict
- Remove localStorage usage for language entirely

## Title
Persist user preferences (language + copy/export transparency) via localforage

## Background
Language was previously persisted via `localStorage`, and the new copy/export transparency toggles need preference persistence as well.

## What changed
- Introduced a single persisted preference record in the web app (localforage): `language`, `copyTransparent`, `exportTransparent`.
- Made the package side persistence-agnostic:
  - Host injects initial values via props.
  - Package notifies the host on changes via callbacks.
- Removed `localStorage` usage for language completely.
- Avoided module-level global language state by storing language per board instance (WeakMap keyed by board), preventing conflicts when multiple boards exist on the same page.

## Notes for review
- Preference loading happens before rendering Drawnix to avoid a “flash” (rendering default language first, then switching).
- This intentionally does not include migration from the previous `localStorage` language value.