### PR TITLE
feat(board): hide native scrollbars

### DIFF
--- a/packages/drawnix/src/drawnix.tsx
+++ b/packages/drawnix/src/drawnix.tsx
@@ -104,7 +104,7 @@ export const Drawnix: React.FC<DrawnixProps> = ({
 }) => {
   const options: PlaitBoardOptions = {
     readonly: false,
-    hideScrollbar: false,
+    hideScrollbar: true,
     disabledScrollOnNonFocus: false,
     themeColors: MindThemeColors,
   };

--- a/packages/react-board/src/styles/index.scss
+++ b/packages/react-board/src/styles/index.scss
@@ -19,13 +19,6 @@
         width: 100%;
         height: 100%;
         overflow: auto;
-        scrollbar-width: none;
-        -ms-overflow-style: none;
-        &::-webkit-scrollbar {
-            display: none;
-            width: 0;
-            height: 0;
-        }
     }
 
     &.disabled-scroll {

--- a/packages/react-board/src/styles/index.scss
+++ b/packages/react-board/src/styles/index.scss
@@ -19,6 +19,13 @@
         width: 100%;
         height: 100%;
         overflow: auto;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+        &::-webkit-scrollbar {
+            display: none;
+            width: 0;
+            height: 0;
+        }
     }
 
     &.disabled-scroll {


### PR DESCRIPTION
## Summary

- Enable Plait's `hideScrollbar` option for the Drawnix board.
- Hide the native browser scrollbar only on the board viewport.

## Context

Refs #202.

This issue has been open for a while, but the implementation turned out to be very small. I opened this PR mainly to confirm whether this behavior is still desired.

The trade-off is that users can no longer manually drag the native scrollbar. Mouse wheel and trackpad scrolling, including horizontal scrolling, still work, and canvas interactions such as middle/right-button dragging are unchanged. In my opinion, this fits the whiteboard canvas model better and makes the board feel more immersive.

@pubuzhixing8  What do you think? Is this still something you would like to have?

## Checks

- `npm run lint`
- `npx oxfmt --check packages/drawnix/src/drawnix.tsx packages/react-board/src/styles/index.scss`
- `npm run build:web`
- Local browser verification on `http://localhost:7200/`
