### PR TITLE
Increase freehand stroke width range

### DIFF
--- a/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.spec.tsx
+++ b/packages/drawnix/src/components/toolbar/freehand-panel/freehand-style-preset-item.spec.tsx
@@ -27,7 +27,7 @@ vi.mock('../../../plugins/freehand/utils', () => ({
 
 vi.mock('../../../plugins/freehand/type', () => ({
   FREEHAND_STROKE_WIDTH_STEP: 0.25,
-  MAX_FREEHAND_STROKE_WIDTH: 12,
+  MAX_FREEHAND_STROKE_WIDTH: 24,
   MIN_FREEHAND_STROKE_WIDTH: 1,
 }));
 
@@ -95,17 +95,18 @@ describe('getFreehandPreviewRadius', () => {
   });
 
   it('maps the maximum stroke width to the maximum preview radius', () => {
-    expect(getFreehandPreviewRadius(12)).toBeCloseTo(5.5);
+    expect(getFreehandPreviewRadius(24)).toBeCloseTo(5.5);
   });
 
   it('clamps out-of-range stroke widths', () => {
     expect(getFreehandPreviewRadius(0)).toBeCloseTo(2);
-    expect(getFreehandPreviewRadius(20)).toBeCloseTo(5.5);
+    expect(getFreehandPreviewRadius(32)).toBeCloseTo(5.5);
   });
 
   it('increases monotonically across the supported stroke-width range', () => {
     expect(getFreehandPreviewRadius(3)).toBeLessThan(getFreehandPreviewRadius(6));
-    expect(getFreehandPreviewRadius(6)).toBeLessThan(getFreehandPreviewRadius(9));
+    expect(getFreehandPreviewRadius(6)).toBeLessThan(getFreehandPreviewRadius(12));
+    expect(getFreehandPreviewRadius(12)).toBeLessThan(getFreehandPreviewRadius(18));
   });
 });
 
@@ -146,7 +147,7 @@ describe('FreehandStylePresetItem', () => {
           preset: {
             id: 'preset-1',
             color: '#FF4500',
-            size: 12,
+            size: 24,
           },
         })}
       />
@@ -157,7 +158,7 @@ describe('FreehandStylePresetItem', () => {
     expect(nextFill?.getAttribute('cx')).toBe(initialCenterX);
     expect(nextFill?.getAttribute('cy')).toBe(initialCenterY);
     expect(nextFill?.getAttribute('r')).not.toBe(initialRadius);
-    expect(nextFill?.getAttribute('r')).toBe(`${getFreehandPreviewRadius(12)}`);
+    expect(nextFill?.getAttribute('r')).toBe(`${getFreehandPreviewRadius(24)}`);
   });
 
   it('renders a dedicated white contrast structure without the standard color ring', () => {

--- a/packages/drawnix/src/plugins/freehand/presets.ts
+++ b/packages/drawnix/src/plugins/freehand/presets.ts
@@ -4,7 +4,9 @@ export const DEFAULT_FREEHAND_STROKE_WIDTH = 2;
 
 export const MIN_FREEHAND_STROKE_WIDTH = 1;
 
-export const MAX_FREEHAND_STROKE_WIDTH = 12;
+// Covers roughly 2x PPI displays (for example, 2K/16-inch) without changing
+// the default fine stroke.
+export const MAX_FREEHAND_STROKE_WIDTH = 24;
 
 export const FREEHAND_STROKE_WIDTH_STEP = 0.25;
 


### PR DESCRIPTION
## Summary

- Increase the Freehand preset stroke-width slider maximum from `12` to `24`.
- Keep the existing default and preset values unchanged, so normal/fine pen behavior does not get heavier by default.
- Update the Freehand preset preview tests to cover the new maximum range.

Fixes #444.

## Why 24

The new maximum is based on common display PPI rather than an arbitrary larger number. Using a 1080P 24-inch monitor as the baseline:

| Scenario | Approx. PPI | Ratio vs. 1080P 24-inch | Stroke width equivalent to 12 |
| --- | ---: | ---: | ---: |
| 1080P 24-inch | 91.8 | 1.00x | 12.0 |
| 2K 24-inch | 122.4 | 1.33x | 16.0 |
| 4K 27-inch | 163.2 | 1.78x | 21.3 |
| 2K 16-inch, 16:9 | 183.6 | 2.00x | 24.0 |
| 2K 16-inch, 16:10 | 188.7 | 2.06x | 24.7 |

With the previous maximum of `12`, high-PPI displays can make the thickest Freehand stroke feel physically much thinner than it does on a typical 1080P 24-inch display. A maximum of `24` covers the roughly 2x PPI case represented by 2K 16-inch displays, while also covering 4K 27-inch displays where the equivalent value is about `21.3`.

This changes the available upper bound only. The default stroke width remains `2`, and the existing presets remain `2`, `6`, and `10`, so the regular writing experience is not made heavier for lower-PPI users.

## Validation

- `npx nx test drawnix --run`
- `npx oxfmt --check packages\drawnix\src\plugins\freehand\presets.ts packages\drawnix\src\components\toolbar\freehand-panel\freehand-style-preset-item.spec.tsx`
- `npx oxlint packages\drawnix\src\plugins\freehand\presets.ts packages\drawnix\src\components\toolbar\freehand-panel\freehand-style-preset-item.spec.tsx`
- `git diff --check`
- Playwright smoke check confirmed the Freehand slider exposes `aria-valuemax="24"` and can reach `24` via keyboard End.