### PR TITLE
Fix stale selection bounding after hand panning

### DIFF
--- a/packages/drawnix/src/drawnix.tsx
+++ b/packages/drawnix/src/drawnix.tsx
@@ -1,12 +1,12 @@
 import { Board, BoardChangeData, Wrapper } from '@plait-board/react-board';
 import {
+  BoardTransforms,
   PlaitBoard,
   PlaitBoardOptions,
   PlaitElement,
   PlaitPlugin,
   PlaitPointerType,
   PlaitTheme,
-  BoardTransforms,
   Selection,
   ThemeColorMode,
   Viewport,
@@ -46,6 +46,7 @@ import type { Language } from './i18n/types';
 import { Tutorial } from './components/tutorial';
 import { LASER_POINTER_CLASS_NAME } from './utils/laser-pointer';
 import { Toast, useToast } from './components/toast/toast';
+import { withHandSelectionBounding } from './plugins/with-hand-selection-bounding';
 
 export type DrawnixProps = {
   value: PlaitElement[];
@@ -208,6 +209,7 @@ export const Drawnix: React.FC<DrawnixProps> = ({
     buildPencilPlugin(updateAppState),
     buildTextLinkPlugin(updateAppState),
     buildToolStateSyncPlugin(syncBoardPointerToToolState),
+    withHandSelectionBounding,
   ];
 
   const containerRef = useRef<HTMLDivElement>(null);

--- a/packages/drawnix/src/plugins/with-hand-selection-bounding.spec.ts
+++ b/packages/drawnix/src/plugins/with-hand-selection-bounding.spec.ts
@@ -10,15 +10,22 @@ import type { PlaitBoard } from '@plait/core';
 
 const mocks = vi.hoisted(() => ({
   activeHost: undefined as SVGGElement | undefined,
+  boardContainer: undefined as HTMLDivElement | undefined,
+  viewportContainer: undefined as HTMLDivElement | undefined,
   getActiveHost: vi.fn(),
+  getBoardContainer: vi.fn(),
+  getViewportContainer: vi.fn(),
   getSelectedElements: vi.fn(),
   isSetViewportOperation: vi.fn(),
+  updateViewportContainerScroll: vi.fn(),
 }));
 
 vi.mock('@plait/core', () => ({
   getSelectedElements: mocks.getSelectedElements,
   PlaitBoard: {
     getActiveHost: mocks.getActiveHost,
+    getBoardContainer: mocks.getBoardContainer,
+    getViewportContainer: mocks.getViewportContainer,
   },
   PlaitOperation: {
     isSetViewportOperation: mocks.isSetViewportOperation,
@@ -28,6 +35,7 @@ vi.mock('@plait/core', () => ({
     selection: 'selection',
   },
   SELECTION_RECTANGLE_BOUNDING_CLASS_NAME: 'selection-rectangle-bounding',
+  updateViewportContainerScroll: mocks.updateViewportContainerScroll,
 }));
 
 const createSvgG = (className?: string) => {
@@ -45,9 +53,19 @@ const createBoard = (overrides: Partial<PlaitBoard> = {}) =>
     afterChange: vi.fn(),
     onChange: vi.fn(),
     pointerDown: vi.fn(),
+    pointerMove: vi.fn(),
+    pointerUp: vi.fn(),
+    globalPointerUp: vi.fn(),
     drawSelectionRectangle: vi.fn(() => createSvgG('selection-rectangle-bounding')),
     ...overrides,
   }) as unknown as PlaitBoard;
+
+const createPointerEvent = (x = 0, y = 0) =>
+  ({
+    x,
+    y,
+    preventDefault: vi.fn(),
+  }) as unknown as PointerEvent & { preventDefault: ReturnType<typeof vi.fn> };
 
 describe('clearHandSelectionBounding', () => {
   beforeEach(() => {
@@ -108,8 +126,15 @@ describe('refreshSelectionBounding', () => {
 describe('withHandSelectionBounding', () => {
   beforeEach(() => {
     mocks.activeHost = createSvgG();
+    mocks.boardContainer = document.createElement('div');
+    mocks.viewportContainer = document.createElement('div');
+    mocks.viewportContainer.scrollLeft = 200;
+    mocks.viewportContainer.scrollTop = 100;
     mocks.getActiveHost.mockReturnValue(mocks.activeHost);
+    mocks.getBoardContainer.mockReturnValue(mocks.boardContainer);
+    mocks.getViewportContainer.mockReturnValue(mocks.viewportContainer);
     mocks.getSelectedElements.mockReturnValue([{ id: 'a' }, { id: 'b' }]);
+    mocks.updateViewportContainerScroll.mockReset();
     mocks.isSetViewportOperation.mockImplementation(
       (operation) => operation.type === 'set_viewport'
     );
@@ -169,5 +194,47 @@ describe('withHandSelectionBounding', () => {
     board.afterChange();
 
     expect(board.drawSelectionRectangle).not.toHaveBeenCalled();
+  });
+
+  it('pans viewport directly during temporary viewport moving', () => {
+    mocks.boardContainer?.classList.add('viewport-moving');
+    const board = createBoard({
+      pointer: PlaitPointerType.selection,
+    });
+    const originalPointerDown = board.pointerDown;
+    const originalPointerMove = board.pointerMove;
+    const originalPointerUp = board.pointerUp;
+    const pointerDownEvent = createPointerEvent(100, 50);
+    const pointerMoveEvent = createPointerEvent(120, 60);
+    const pointerUpEvent = createPointerEvent(120, 60);
+
+    withHandSelectionBounding(board);
+    board.pointerDown(pointerDownEvent);
+    board.pointerMove(pointerMoveEvent);
+    board.pointerUp(pointerUpEvent);
+
+    expect(originalPointerDown).not.toHaveBeenCalled();
+    expect(originalPointerMove).not.toHaveBeenCalled();
+    expect(originalPointerUp).not.toHaveBeenCalled();
+    expect(mocks.updateViewportContainerScroll).toHaveBeenCalledWith(board, 180, 90, false);
+    expect(pointerDownEvent.preventDefault).toHaveBeenCalled();
+    expect(pointerMoveEvent.preventDefault).toHaveBeenCalled();
+    expect(pointerUpEvent.preventDefault).toHaveBeenCalled();
+  });
+
+  it('passes pointer events through when the board is not temporary viewport moving', () => {
+    const board = createBoard({
+      pointer: PlaitPointerType.selection,
+    });
+    const originalPointerDown = board.pointerDown;
+    const originalPointerMove = board.pointerMove;
+
+    withHandSelectionBounding(board);
+    board.pointerDown(createPointerEvent());
+    board.pointerMove(createPointerEvent());
+
+    expect(originalPointerDown).toHaveBeenCalled();
+    expect(originalPointerMove).toHaveBeenCalled();
+    expect(mocks.updateViewportContainerScroll).not.toHaveBeenCalled();
   });
 });

--- a/packages/drawnix/src/plugins/with-hand-selection-bounding.spec.ts
+++ b/packages/drawnix/src/plugins/with-hand-selection-bounding.spec.ts
@@ -1,0 +1,173 @@
+import { PlaitPointerType } from '@plait/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearHandSelectionBounding,
+  HAND_SELECTION_BOUNDING_CLASS_NAME,
+  refreshSelectionBounding,
+  withHandSelectionBounding,
+} from './with-hand-selection-bounding';
+import type { PlaitBoard } from '@plait/core';
+
+const mocks = vi.hoisted(() => ({
+  activeHost: undefined as SVGGElement | undefined,
+  getActiveHost: vi.fn(),
+  getSelectedElements: vi.fn(),
+  isSetViewportOperation: vi.fn(),
+}));
+
+vi.mock('@plait/core', () => ({
+  getSelectedElements: mocks.getSelectedElements,
+  PlaitBoard: {
+    getActiveHost: mocks.getActiveHost,
+  },
+  PlaitOperation: {
+    isSetViewportOperation: mocks.isSetViewportOperation,
+  },
+  PlaitPointerType: {
+    hand: 'hand',
+    selection: 'selection',
+  },
+  SELECTION_RECTANGLE_BOUNDING_CLASS_NAME: 'selection-rectangle-bounding',
+}));
+
+const createSvgG = (className?: string) => {
+  const element = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  if (className) {
+    element.classList.add(className);
+  }
+  return element;
+};
+
+const createBoard = (overrides: Partial<PlaitBoard> = {}) =>
+  ({
+    pointer: PlaitPointerType.hand,
+    operations: [{ type: 'set_viewport' }],
+    afterChange: vi.fn(),
+    onChange: vi.fn(),
+    pointerDown: vi.fn(),
+    drawSelectionRectangle: vi.fn(() => createSvgG('selection-rectangle-bounding')),
+    ...overrides,
+  }) as unknown as PlaitBoard;
+
+describe('clearHandSelectionBounding', () => {
+  beforeEach(() => {
+    mocks.activeHost = createSvgG();
+    mocks.getActiveHost.mockReturnValue(mocks.activeHost);
+  });
+
+  it('removes only hand-generated selection bounding rectangles', () => {
+    const handBounding = createSvgG(HAND_SELECTION_BOUNDING_CLASS_NAME);
+    const regularBounding = createSvgG('selection-rectangle-bounding');
+    mocks.activeHost?.append(handBounding, regularBounding);
+    const board = createBoard();
+
+    clearHandSelectionBounding(board);
+
+    expect(handBounding.isConnected).toBe(false);
+    expect(mocks.activeHost?.contains(regularBounding)).toBe(true);
+  });
+});
+
+describe('refreshSelectionBounding', () => {
+  beforeEach(() => {
+    mocks.activeHost = createSvgG();
+    mocks.getActiveHost.mockReturnValue(mocks.activeHost);
+    mocks.getSelectedElements.mockReturnValue([{ id: 'a' }, { id: 'b' }]);
+    mocks.isSetViewportOperation.mockReset();
+  });
+
+  it('replaces stale bounding rectangles with one based on current selection', () => {
+    const staleBounding = createSvgG('selection-rectangle-bounding');
+    mocks.activeHost?.append(staleBounding);
+    const board = createBoard();
+
+    refreshSelectionBounding(board);
+
+    expect(staleBounding.isConnected).toBe(false);
+    expect(board.drawSelectionRectangle).toHaveBeenCalled();
+    expect(
+      mocks.activeHost?.querySelector(`.${HAND_SELECTION_BOUNDING_CLASS_NAME}`)
+    ).not.toBeNull();
+    expect(mocks.activeHost?.querySelectorAll('.selection-rectangle-bounding')).toHaveLength(1);
+  });
+
+  it('removes the stale bounding rectangle when fewer than two elements are selected', () => {
+    const staleBounding = createSvgG('selection-rectangle-bounding');
+    mocks.activeHost?.append(staleBounding);
+    mocks.getSelectedElements.mockReturnValue([{ id: 'a' }]);
+    const board = createBoard();
+
+    refreshSelectionBounding(board);
+
+    expect(staleBounding.isConnected).toBe(false);
+    expect(board.drawSelectionRectangle).not.toHaveBeenCalled();
+    expect(mocks.activeHost?.querySelectorAll('.selection-rectangle-bounding')).toHaveLength(0);
+  });
+});
+
+describe('withHandSelectionBounding', () => {
+  beforeEach(() => {
+    mocks.activeHost = createSvgG();
+    mocks.getActiveHost.mockReturnValue(mocks.activeHost);
+    mocks.getSelectedElements.mockReturnValue([{ id: 'a' }, { id: 'b' }]);
+    mocks.isSetViewportOperation.mockImplementation(
+      (operation) => operation.type === 'set_viewport'
+    );
+  });
+
+  it('refreshes selection bounding after hand viewport changes', () => {
+    const staleBounding = createSvgG('selection-rectangle-bounding');
+    mocks.activeHost?.append(staleBounding);
+    const board = createBoard();
+    const originalAfterChange = board.afterChange;
+
+    withHandSelectionBounding(board);
+    board.afterChange();
+
+    expect(originalAfterChange).toHaveBeenCalled();
+    expect(staleBounding.isConnected).toBe(false);
+    expect(board.drawSelectionRectangle).toHaveBeenCalled();
+  });
+
+  it('clears hand-generated bounding before selection onChange runs', () => {
+    const handBounding = createSvgG(HAND_SELECTION_BOUNDING_CLASS_NAME);
+    const regularBounding = createSvgG('selection-rectangle-bounding');
+    mocks.activeHost?.append(handBounding, regularBounding);
+    const board = createBoard({
+      pointer: PlaitPointerType.selection,
+    });
+    const originalOnChange = board.onChange;
+
+    withHandSelectionBounding(board);
+    board.onChange();
+
+    expect(originalOnChange).toHaveBeenCalled();
+    expect(handBounding.isConnected).toBe(false);
+    expect(mocks.activeHost?.contains(regularBounding)).toBe(true);
+  });
+
+  it('clears hand-generated bounding after non-hand afterChange runs', () => {
+    const handBounding = createSvgG(HAND_SELECTION_BOUNDING_CLASS_NAME);
+    mocks.activeHost?.append(handBounding);
+    const board = createBoard({
+      pointer: PlaitPointerType.selection,
+    });
+
+    withHandSelectionBounding(board);
+    board.afterChange();
+
+    expect(handBounding.isConnected).toBe(false);
+    expect(board.drawSelectionRectangle).not.toHaveBeenCalled();
+  });
+
+  it('does not refresh selection bounding outside hand viewport changes', () => {
+    const board = createBoard({
+      pointer: PlaitPointerType.selection,
+    });
+
+    withHandSelectionBounding(board);
+    board.afterChange();
+
+    expect(board.drawSelectionRectangle).not.toHaveBeenCalled();
+  });
+});

--- a/packages/drawnix/src/plugins/with-hand-selection-bounding.ts
+++ b/packages/drawnix/src/plugins/with-hand-selection-bounding.ts
@@ -4,9 +4,11 @@ import {
   PlaitOperation,
   PlaitPointerType,
   SELECTION_RECTANGLE_BOUNDING_CLASS_NAME,
+  updateViewportContainerScroll,
 } from '@plait/core';
 
 export const HAND_SELECTION_BOUNDING_CLASS_NAME = 'drawnix-hand-selection-bounding';
+const VIEWPORT_MOVING_CLASS_NAME = 'viewport-moving';
 
 export const clearHandSelectionBounding = (board: PlaitBoard) => {
   const activeHost = PlaitBoard.getActiveHost(board);
@@ -31,7 +33,26 @@ export const refreshSelectionBounding = (board: PlaitBoard) => {
 };
 
 export const withHandSelectionBounding = (board: PlaitBoard) => {
-  const { afterChange, onChange, pointerDown } = board;
+  const { afterChange, onChange, pointerDown, pointerMove, pointerUp, globalPointerUp } = board;
+  let temporaryViewportMovingPoint: { x: number; y: number } | null = null;
+
+  const isTemporaryViewportMove = () => {
+    return (
+      board.pointer !== PlaitPointerType.hand &&
+      PlaitBoard.getBoardContainer(board).classList.contains(VIEWPORT_MOVING_CLASS_NAME)
+    );
+  };
+
+  const moveTemporaryViewport = (event: PointerEvent) => {
+    if (!temporaryViewportMovingPoint) {
+      return;
+    }
+    const viewportContainer = PlaitBoard.getViewportContainer(board);
+    const left = viewportContainer.scrollLeft - (event.x - temporaryViewportMovingPoint.x);
+    const top = viewportContainer.scrollTop - (event.y - temporaryViewportMovingPoint.y);
+    updateViewportContainerScroll(board, left, top, false);
+    temporaryViewportMovingPoint = { x: event.x, y: event.y };
+  };
 
   const clearIfNotHand = () => {
     if (board.pointer !== PlaitPointerType.hand) {
@@ -41,7 +62,43 @@ export const withHandSelectionBounding = (board: PlaitBoard) => {
 
   board.pointerDown = (event) => {
     clearIfNotHand();
+    if (isTemporaryViewportMove()) {
+      temporaryViewportMovingPoint = { x: event.x, y: event.y };
+      event.preventDefault();
+      return;
+    }
     pointerDown(event);
+  };
+
+  board.pointerMove = (event) => {
+    if (temporaryViewportMovingPoint) {
+      if (isTemporaryViewportMove()) {
+        moveTemporaryViewport(event);
+        event.preventDefault();
+      } else {
+        temporaryViewportMovingPoint = null;
+      }
+      return;
+    }
+    pointerMove(event);
+  };
+
+  board.pointerUp = (event) => {
+    if (temporaryViewportMovingPoint) {
+      temporaryViewportMovingPoint = null;
+      event.preventDefault();
+      return;
+    }
+    pointerUp(event);
+  };
+
+  board.globalPointerUp = (event) => {
+    if (temporaryViewportMovingPoint) {
+      temporaryViewportMovingPoint = null;
+      event.preventDefault();
+      return;
+    }
+    globalPointerUp(event);
   };
 
   board.onChange = () => {

--- a/packages/drawnix/src/plugins/with-hand-selection-bounding.ts
+++ b/packages/drawnix/src/plugins/with-hand-selection-bounding.ts
@@ -1,0 +1,65 @@
+import {
+  getSelectedElements,
+  PlaitBoard,
+  PlaitOperation,
+  PlaitPointerType,
+  SELECTION_RECTANGLE_BOUNDING_CLASS_NAME,
+} from '@plait/core';
+
+export const HAND_SELECTION_BOUNDING_CLASS_NAME = 'drawnix-hand-selection-bounding';
+
+export const clearHandSelectionBounding = (board: PlaitBoard) => {
+  const activeHost = PlaitBoard.getActiveHost(board);
+  activeHost
+    .querySelectorAll(`.${HAND_SELECTION_BOUNDING_CLASS_NAME}`)
+    .forEach((element) => element.remove());
+};
+
+export const refreshSelectionBounding = (board: PlaitBoard) => {
+  const activeHost = PlaitBoard.getActiveHost(board);
+  activeHost
+    .querySelectorAll(`.${SELECTION_RECTANGLE_BOUNDING_CLASS_NAME}`)
+    .forEach((element) => element.remove());
+
+  if (getSelectedElements(board).length > 1) {
+    const selectionRectangle = board.drawSelectionRectangle();
+    if (selectionRectangle) {
+      selectionRectangle.classList.add(HAND_SELECTION_BOUNDING_CLASS_NAME);
+      activeHost.append(selectionRectangle);
+    }
+  }
+};
+
+export const withHandSelectionBounding = (board: PlaitBoard) => {
+  const { afterChange, onChange, pointerDown } = board;
+
+  const clearIfNotHand = () => {
+    if (board.pointer !== PlaitPointerType.hand) {
+      clearHandSelectionBounding(board);
+    }
+  };
+
+  board.pointerDown = (event) => {
+    clearIfNotHand();
+    pointerDown(event);
+  };
+
+  board.onChange = () => {
+    clearIfNotHand();
+    onChange();
+  };
+
+  board.afterChange = () => {
+    afterChange();
+    const hasViewportChanged = board.operations.some((operation) =>
+      PlaitOperation.isSetViewportOperation(operation)
+    );
+    if (board.pointer === PlaitPointerType.hand && hasViewportChanged) {
+      refreshSelectionBounding(board);
+      return;
+    }
+    clearIfNotHand();
+  };
+
+  return board;
+};


### PR DESCRIPTION
Fixes #394.

## Summary

This PR fixes the stale multi-selection bounding rectangle that appears after selecting mixed elements, switching to hand mode, and panning the canvas.

The selected elements are preserved when switching tools. The fix refreshes the visual multi-selection bounding rectangle while panning in hand mode, avoids leaving an extra bounding rectangle behind after switching back to selection mode, and prevents temporary hand-mode drags from being handled by selection/drawing plugins.

## Investigation

I reproduced the issue with a mixed selection containing an image element and a freehand stroke. After switching to hand mode and dragging the viewport, the selected element active rectangles moved with the viewport, but the top-level multi-selection bounding rectangle could remain stale and appear offset.

The behavior comes from `@plait/core` selection handling:

- `withSelection.afterChange` redraws the multi-selection rectangle only when selection handling is active.
- `isHandleSelection(board)` returns false when `board.pointer === PlaitPointerType.hand`.
- That is reasonable for preventing new selection interactions in hand mode, but it also means viewport changes in hand mode do not refresh the existing selection overlay.

So the root issue is not that the selection state is lost. The selected elements remain selected. The stale part is the visual bounding rectangle overlay.

While checking the hand behavior, I also tested the temporary hand path, where the user holds Space while the active pointer is still selection. In that path the board container has the `viewport-moving` class, but inner Drawnix/Plait pointer handlers can still receive the drag. When the drag starts inside a selected filled area, those handlers may treat the gesture as a selection/drawing interaction instead of pure viewport panning.

## Current approach

This PR adds a small Drawnix plugin, `withHandSelectionBounding`, which:

- detects viewport changes while the board is in hand mode;
- removes stale multi-selection bounding rectangles;
- redraws the current multi-selection bounding rectangle with `board.drawSelectionRectangle()`;
- marks the hand-mode rectangle with a Drawnix-specific class;
- clears only that temporary hand-mode rectangle when leaving hand mode, so Plait's normal selection overlay lifecycle can take over again;
- intercepts temporary hand-mode drags while `viewport-moving` is active, updates the viewport directly, and does not forward that pointer sequence to selection/drawing handlers.

This keeps the selection state intact and avoids the duplicate bounding rectangle that can otherwise appear when switching back to selection mode and dragging a selection area. It also makes hand behavior consistent: both toolbar hand mode and Space temporary hand mode pan the viewport instead of moving selected elements or triggering drawing behavior from the selected area's fill.

## Should this move into Plait core?

This fix is intentionally scoped to Drawnix so the issue can be fixed without waiting for a dependency change. That said, the underlying behavior looks like a lower-level Plait concern.

It may be better for Plait core to separate these responsibilities:

- hand mode should not start or update selection interactions;
- existing selection overlays should still be refreshed after viewport changes;
- temporary viewport-moving gestures should be treated as viewport gestures only, even when the active pointer is still a selection/drawing pointer.

If that direction sounds right, this Drawnix-side plugin can be replaced later by a Plait core fix.

## Validation

Tested locally on `http://localhost:4200/` with a mixed image + freehand selection:

1. Select both elements.
2. Switch to hand mode.
3. Pan the canvas.
4. Switch back to selection mode.
5. Drag a selection area again.

The selection is preserved, the bounding rectangle follows the viewport correctly, and no duplicate bounding rectangle remains after switching back to selection mode.

Also tested the temporary hand path:

1. Select both an image element and a freehand stroke.
2. Hold Space while the active tool is still selection.
3. Drag from inside the selected filled area.

The viewport pans, the selected elements are not moved, and no extra drawing/selection interaction is created.

Automated checks:

- `npx oxfmt --check packages/drawnix/src/drawnix.tsx packages/drawnix/src/plugins/with-hand-selection-bounding.ts packages/drawnix/src/plugins/with-hand-selection-bounding.spec.ts`
- `npx nx test drawnix`
- `npm run lint`
- `npm run build:web`

`npm run build:web` still reports the existing large chunk size warning.
