### PR TITLE
Fix middle mouse panning in freehand tools

### DIFF
--- a/packages/drawnix/src/plugins/freehand/pointer-button.spec.ts
+++ b/packages/drawnix/src/plugins/freehand/pointer-button.spec.ts
@@ -40,6 +40,7 @@ vi.mock('@plait/core', () => ({
   },
   distanceBetweenPointAndPoint: (x1: number, y1: number, x2: number, y2: number) =>
     Math.hypot(x2 - x1, y2 - y1),
+  isMainPointer: (event: MouseEvent) => event.button === 0,
   throttleRAF: (_board: unknown, _key: string, callback: () => void) => callback(),
   toHostPoint: (_board: unknown, x: number, y: number) => [x, y],
   toViewBoxPoint: (_board: unknown, point: [number, number]) => point,

--- a/packages/drawnix/src/plugins/freehand/pointer-button.spec.ts
+++ b/packages/drawnix/src/plugins/freehand/pointer-button.spec.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  insertNode: vi.fn(),
+  removeElements: vi.fn(),
+}));
+
+vi.mock('@plait/common', () => ({
+  isDrawingMode: () => true,
+}));
+
+vi.mock('@plait-board/react-board', () => ({
+  isTwoFingerMode: () => false,
+}));
+
+vi.mock('@plait/core', () => ({
+  CoreTransforms: {
+    removeElements: mocks.removeElements,
+  },
+  DEFAULT_COLOR: '#000000',
+  PlaitBoard: {
+    getElementTopHost: () => ({}),
+    getPointer: (board: { pointer: string }) => board.pointer,
+    isInPointer: (board: { pointer: string }, pointers: string[]) =>
+      pointers.includes(board.pointer),
+  },
+  PlaitElement: {
+    getElementG: () => ({ style: {} }),
+  },
+  ThemeColorMode: {
+    colorful: 'colorful',
+    dark: 'dark',
+    default: 'default',
+    retro: 'retro',
+    soft: 'soft',
+    starry: 'starry',
+  },
+  Transforms: {
+    insertNode: mocks.insertNode,
+  },
+  distanceBetweenPointAndPoint: (x1: number, y1: number, x2: number, y2: number) =>
+    Math.hypot(x2 - x1, y2 - y1),
+  throttleRAF: (_board: unknown, _key: string, callback: () => void) => callback(),
+  toHostPoint: (_board: unknown, x: number, y: number) => [x, y],
+  toViewBoxPoint: (_board: unknown, point: [number, number]) => point,
+}));
+
+vi.mock('./freehand.generator', () => ({
+  FreehandGenerator: class {
+    destroy = vi.fn();
+    processDrawing = vi.fn();
+  },
+}));
+
+vi.mock('./smoother', () => ({
+  FreehandSmoother: class {
+    process(point: [number, number]) {
+      return point;
+    }
+    reset = vi.fn();
+  },
+}));
+
+vi.mock('../../utils/laser-pointer', () => ({
+  LaserPointer: class {
+    destroy = vi.fn();
+    init = vi.fn();
+  },
+}));
+
+import { withFreehandCreate } from './with-freehand-create';
+import { withFreehandErase } from './with-freehand-erase';
+import { FreehandShape } from './type';
+
+const createPointerEvent = (button: number) =>
+  ({
+    button,
+    x: 10,
+    y: 10,
+  }) as PointerEvent;
+
+const createBoard = (pointer: string) => ({
+  children: [],
+  globalPointerUp: vi.fn(),
+  pointer,
+  pointerDown: vi.fn(),
+  pointerMove: vi.fn(),
+  pointerUp: vi.fn(),
+  theme: {
+    themeColorMode: 'default',
+  },
+  touchStart: vi.fn(),
+});
+
+describe('freehand pointer buttons', () => {
+  it('does not start freehand drawing from the middle mouse button', () => {
+    const board = createBoard(FreehandShape.feltTipPen);
+    const originalPointerDown = board.pointerDown;
+
+    withFreehandCreate(board as any);
+
+    board.pointerDown(createPointerEvent(1));
+    board.pointerMove(createPointerEvent(1));
+    board.pointerUp(createPointerEvent(1));
+
+    expect(originalPointerDown).toHaveBeenCalledOnce();
+    expect(mocks.insertNode).not.toHaveBeenCalled();
+  });
+
+  it('does not start freehand erasing from the middle mouse button', () => {
+    const board = createBoard(FreehandShape.eraser);
+    const originalPointerDown = board.pointerDown;
+
+    withFreehandErase(board as any);
+
+    board.pointerDown(createPointerEvent(1));
+    board.pointerMove(createPointerEvent(1));
+    board.pointerUp(createPointerEvent(1));
+
+    expect(originalPointerDown).toHaveBeenCalledOnce();
+    expect(mocks.removeElements).not.toHaveBeenCalled();
+  });
+});

--- a/packages/drawnix/src/plugins/freehand/utils.ts
+++ b/packages/drawnix/src/plugins/freehand/utils.ts
@@ -35,10 +35,6 @@ export function getFreehandPointers() {
   return [FreehandShape.feltTipPen, FreehandShape.eraser];
 }
 
-export const isPrimaryPointerButton = (event: PointerEvent) => {
-  return event.button === 0;
-};
-
 export const getFreehandDrawOptions = (board: PlaitBoard) => {
   const appState = (board as PlaitBoard & { appState?: FreehandAppState }).appState;
   const activePresetIndex = appState?.toolState?.activeFreehandPresetIndex || 0;

--- a/packages/drawnix/src/plugins/freehand/utils.ts
+++ b/packages/drawnix/src/plugins/freehand/utils.ts
@@ -35,6 +35,10 @@ export function getFreehandPointers() {
   return [FreehandShape.feltTipPen, FreehandShape.eraser];
 }
 
+export const isPrimaryPointerButton = (event: PointerEvent) => {
+  return event.button === 0;
+};
+
 export const getFreehandDrawOptions = (board: PlaitBoard) => {
   const appState = (board as PlaitBoard & { appState?: FreehandAppState }).appState;
   const activePresetIndex = appState?.toolState?.activeFreehandPresetIndex || 0;

--- a/packages/drawnix/src/plugins/freehand/with-freehand-create.ts
+++ b/packages/drawnix/src/plugins/freehand/with-freehand-create.ts
@@ -7,7 +7,12 @@ import {
   toViewBoxPoint,
 } from '@plait/core';
 import { isDrawingMode } from '@plait/common';
-import { createFreehandElement, getFreehandDrawOptions, getFreehandPointers } from './utils';
+import {
+  createFreehandElement,
+  getFreehandDrawOptions,
+  getFreehandPointers,
+  isPrimaryPointerButton,
+} from './utils';
 import { Freehand, FreehandShape } from './type';
 import { FreehandGenerator } from './freehand.generator';
 import { FreehandSmoother } from './smoother';
@@ -64,7 +69,7 @@ export const withFreehandCreate = (board: PlaitBoard) => {
   board.pointerDown = (event: PointerEvent) => {
     const freehandPointers = getFreehandPointers();
     const isFreehandPointer = PlaitBoard.isInPointer(board, freehandPointers);
-    if (isFreehandPointer && isDrawingMode(board)) {
+    if (isFreehandPointer && isDrawingMode(board) && isPrimaryPointerButton(event)) {
       isDrawing = true;
       originScreenPoint = [event.x, event.y];
       const smoothingPoint = smoother.process(originScreenPoint) as Point;

--- a/packages/drawnix/src/plugins/freehand/with-freehand-create.ts
+++ b/packages/drawnix/src/plugins/freehand/with-freehand-create.ts
@@ -3,16 +3,12 @@ import {
   Point,
   Transforms,
   distanceBetweenPointAndPoint,
+  isMainPointer,
   toHostPoint,
   toViewBoxPoint,
 } from '@plait/core';
 import { isDrawingMode } from '@plait/common';
-import {
-  createFreehandElement,
-  getFreehandDrawOptions,
-  getFreehandPointers,
-  isPrimaryPointerButton,
-} from './utils';
+import { createFreehandElement, getFreehandDrawOptions, getFreehandPointers } from './utils';
 import { Freehand, FreehandShape } from './type';
 import { FreehandGenerator } from './freehand.generator';
 import { FreehandSmoother } from './smoother';
@@ -69,7 +65,7 @@ export const withFreehandCreate = (board: PlaitBoard) => {
   board.pointerDown = (event: PointerEvent) => {
     const freehandPointers = getFreehandPointers();
     const isFreehandPointer = PlaitBoard.isInPointer(board, freehandPointers);
-    if (isFreehandPointer && isDrawingMode(board) && isPrimaryPointerButton(event)) {
+    if (isFreehandPointer && isDrawingMode(board) && isMainPointer(event)) {
       isDrawing = true;
       originScreenPoint = [event.x, event.y];
       const smoothingPoint = smoother.process(originScreenPoint) as Point;

--- a/packages/drawnix/src/plugins/freehand/with-freehand-erase.ts
+++ b/packages/drawnix/src/plugins/freehand/with-freehand-erase.ts
@@ -7,7 +7,7 @@ import {
   toViewBoxPoint,
 } from '@plait/core';
 import { isDrawingMode } from '@plait/common';
-import { isHitFreehand } from './utils';
+import { isHitFreehand, isPrimaryPointerButton } from './utils';
 import { Freehand, FreehandShape } from './type';
 import { CoreTransforms } from '@plait/core';
 import { LaserPointer } from '../../utils/laser-pointer';
@@ -66,7 +66,7 @@ export const withFreehandErase = (board: PlaitBoard) => {
   board.pointerDown = (event: PointerEvent) => {
     const isEraserPointer = PlaitBoard.isInPointer(board, [FreehandShape.eraser]);
 
-    if (isEraserPointer && isDrawingMode(board)) {
+    if (isEraserPointer && isDrawingMode(board) && isPrimaryPointerButton(event)) {
       isErasing = true;
       elementsToDelete.clear();
       const currentPoint: Point = [event.x, event.y];

--- a/packages/drawnix/src/plugins/freehand/with-freehand-erase.ts
+++ b/packages/drawnix/src/plugins/freehand/with-freehand-erase.ts
@@ -1,15 +1,16 @@
 import {
+  CoreTransforms,
   PlaitBoard,
   PlaitElement,
   Point,
+  isMainPointer,
   throttleRAF,
   toHostPoint,
   toViewBoxPoint,
 } from '@plait/core';
 import { isDrawingMode } from '@plait/common';
-import { isHitFreehand, isPrimaryPointerButton } from './utils';
+import { isHitFreehand } from './utils';
 import { Freehand, FreehandShape } from './type';
-import { CoreTransforms } from '@plait/core';
 import { LaserPointer } from '../../utils/laser-pointer';
 import { isTwoFingerMode } from '@plait-board/react-board';
 
@@ -66,7 +67,7 @@ export const withFreehandErase = (board: PlaitBoard) => {
   board.pointerDown = (event: PointerEvent) => {
     const isEraserPointer = PlaitBoard.isInPointer(board, [FreehandShape.eraser]);
 
-    if (isEraserPointer && isDrawingMode(board) && isPrimaryPointerButton(event)) {
+    if (isEraserPointer && isDrawingMode(board) && isMainPointer(event)) {
       isErasing = true;
       elementsToDelete.clear();
       const currentPoint: Point = [event.x, event.y];


### PR DESCRIPTION
## Summary

- use `isMainPointer` from `@plait/core` so freehand pen/eraser pointer-button handling shares the core pointer semantics
- let middle mouse pointer events continue to the shared board handlers so canvas panning stays consistent
- add coverage for middle-button behavior in freehand pen and eraser modes

Closes #446

## Review follow-up

- addressed the requested change in `1dd2b7d` by removing the local `event.button === 0` helper and reusing the core helper in both freehand create and erase handlers

## Manual browser verification

Re-ran the app locally with `npm start` and verified the actual board in Chromium:

- opened `http://localhost:7200/` from the local Vite server
- selected the freehand pen tool and confirmed a primary-button drag creates a visible stroke
- with the pen still active, middle-button drag panned the board (`viewport-container` scroll changed from `640/360` to `800/440`) and did not create another stroke
- switched to the eraser tool, middle-button drag panned again (`800/440` to `660/350`) and the existing stroke remained visible
- checked the browser console after the flow: no console errors

## Verification

- `npx nx test drawnix`
- `npx oxfmt --check packages/drawnix/src/plugins/freehand/with-freehand-create.ts packages/drawnix/src/plugins/freehand/with-freehand-erase.ts packages/drawnix/src/plugins/freehand/utils.ts packages/drawnix/src/plugins/freehand/pointer-button.spec.ts`
- `npx oxlint packages/drawnix/src/plugins/freehand/with-freehand-create.ts packages/drawnix/src/plugins/freehand/with-freehand-erase.ts packages/drawnix/src/plugins/freehand/utils.ts packages/drawnix/src/plugins/freehand/pointer-button.spec.ts`