### PR TITLE
Hide board viewport scrollbars

### DIFF
--- a/packages/drawnix/src/styles/index.scss
+++ b/packages/drawnix/src/styles/index.scss
@@ -151,6 +151,17 @@
 }
 
 .plait-board-container {
+    .viewport-container {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+
+        &::-webkit-scrollbar {
+            display: none;
+            width: 0;
+            height: 0;
+        }
+    }
+
     &.pointer-eraser {
         .board-host-svg {
             cursor: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgMCAyMCAyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTAiIGN5PSIxMCIgcj0iNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjNjY2IiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8L3N2Zz4=') 10 10, crosshair !important;


### PR DESCRIPTION
## Summary

- hide the native board viewport scrollbars in Drawnix
- keep `overflow: auto` so existing scrolling and panning behavior still works
- scope the change to the board viewport instead of changing text/editor scroll areas

Closes #202

## Manual browser verification

Ran the app locally with `npm start` and checked the actual board in Chromium:

- opened `http://localhost:7200/`
- confirmed `.viewport-container` keeps `overflow: auto`
- confirmed computed `scrollbar-width` is `none`
- changed `scrollLeft/scrollTop` from `640/360` to `720/420` programmatically to verify scrolling still works
- used the hand tool to drag-pan the board and confirmed scroll changed again to `800/470`
- checked the browser console after the flow: no console errors

## Verification

- `npx nx build web`
- `npx nx test drawnix`