### PR TITLE
fix(drawnix): keep freehand selection aligned when zooming

### DIFF
--- a/packages/drawnix/src/plugins/freehand/freehand.component.spec.ts
+++ b/packages/drawnix/src/plugins/freehand/freehand.component.spec.ts
@@ -1,0 +1,57 @@
+import { BOARD_TO_ELEMENT_HOST, createG, createTestingBoard, PlaitBoard } from '@plait/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FreehandComponent } from './freehand.component';
+import { Freehand, FreehandShape } from './type';
+
+describe('FreehandComponent', () => {
+  let board: PlaitBoard;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    BOARD_TO_ELEMENT_HOST.delete(board);
+  });
+
+  it('refreshes its active section on request', () => {
+    const element = {
+      id: 'freehand',
+      type: 'freehand',
+      shape: FreehandShape.feltTipPen,
+      points: [
+        [0, 0],
+        [10, 10],
+      ],
+    } as Freehand;
+    board = createTestingBoard([], [element]);
+    const activeHost = createG();
+    BOARD_TO_ELEMENT_HOST.set(board, {
+      lowerHost: createG(),
+      host: createG(),
+      upperHost: createG(),
+      topHost: createG(),
+      activeHost,
+      container: document.createElement('div'),
+      viewportContainer: document.createElement('div'),
+    });
+    const component = new FreehandComponent();
+    component.context = {
+      board,
+      element,
+      parent: board,
+      index: 0,
+      selected: true,
+      hasThemeChanged: false,
+    };
+    component.initializeGenerator();
+    const processDrawing = vi
+      .spyOn(component.activeGenerator, 'processDrawing')
+      .mockImplementation(() => {});
+
+    board.viewport.zoom = 2;
+    component.getRef().updateActiveSection();
+
+    expect(processDrawing).toHaveBeenCalledOnce();
+    expect(processDrawing).toHaveBeenCalledWith(element, activeHost, {
+      selected: true,
+    });
+  });
+});

--- a/packages/drawnix/src/plugins/freehand/freehand.component.ts
+++ b/packages/drawnix/src/plugins/freehand/freehand.component.ts
@@ -38,6 +38,11 @@ export class FreehandComponent
       },
     });
     this.generator = new FreehandGenerator(this.board);
+    this.getRef().updateActiveSection = () => {
+      this.activeGenerator.processDrawing(this.element, PlaitBoard.getActiveHost(this.board), {
+        selected: this.selected,
+      });
+    };
   }
 
   initialize(): void {


### PR DESCRIPTION
Found while testing zoom behavior. With a freehand element selected, its selection outline could stay at the previous position and scale while the rest of the selection updated.

`FreehandComponent` was missing the active-section refresh hook, so the outline was not redrawn after viewport changes. This adds the missing hook and a focused regression test.

Tested with:
- Drawnix tests (26 passed)
- Drawnix build
- Manual A/B zoom testing with selected freehand elements
