### PR TITLE
fix: show More Options for image selections

### DIFF
--- a/packages/drawnix/src/components/toolbar/popup-toolbar/popup-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/popup-toolbar/popup-toolbar.tsx
@@ -49,10 +49,8 @@ export const PopupToolbar = () => {
   const selectedElements = getSelectedElements(board);
   const [movingOrDragging, setMovingOrDragging] = useState(false);
   const movingOrDraggingRef = useRef(movingOrDragging);
-  const open =
-    selectedElements.length > 0 &&
-    !isSelectionMoving(board) &&
-    !selectedElements.some(PlaitDrawElement.isImage);
+  const hasImage = selectedElements.some(PlaitDrawElement.isImage);
+  const open = selectedElements.length > 0 && !isSelectionMoving(board);
   const { viewport, selection, children } = board;
   const { refs, floatingStyles } = useFloating({
     placement: 'right-start',
@@ -76,7 +74,7 @@ export const PopupToolbar = () => {
   } = {
     fill: 'red',
   };
-  if (open && !movingOrDragging) {
+  if (open && !movingOrDragging && !hasImage) {
     const hasFill =
       selectedElements.some((value) => hasFillProperty(board, value)) &&
       !PlaitBoard.hasBeenTextEditing(board);


### PR DESCRIPTION
## Summary

- Keep the popup toolbar available when the selection contains an image.
- Show only **More Options** for image and mixed-image selections, preserving the existing behavior for style controls.

## Why

The popup toolbar was hidden whenever any selected element was an image. After the More Options menu was added, this also made its generic duplicate, delete, and copy actions unavailable for those selections.

Closes #439.

## Testing

- `npx.cmd oxfmt --check packages/drawnix/src/components/toolbar/popup-toolbar/popup-toolbar.tsx`
- `npx.cmd oxlint packages/drawnix/src/components/toolbar/popup-toolbar/popup-toolbar.tsx`
- `npx.cmd nx test drawnix --skip-nx-cache`
- `npx.cmd nx build drawnix --skip-nx-cache`
- Manually verified image and mixed-image selections in the local app.
