### PR TITLE
docs: add AtomGit badge to project READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@
   <br />
 
   <a href="https://trendshift.io/repositories/13979" target="_blank"><img src="https://trendshift.io/api/badge/repositories/13979" alt="plait-board%2Fdrawnix | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
+  <br />
+
+  <a href="https://atomgit.com/plait-board/drawnix" target="_blank"><img src="https://atomgit.com/plait-board/drawnix/star/new_badge.svg" alt="AtomGit G-Star" height="54" /></a>
 </div>
 
 [*English README*](https://github.com/plait-board/drawnix/blob/develop/README_en.md)

--- a/README_en.md
+++ b/README_en.md
@@ -34,6 +34,10 @@
   <br />
 
   <a href="https://trendshift.io/repositories/13979" target="_blank"><img src="https://trendshift.io/api/badge/repositories/13979" alt="plait-board%2Fdrawnix | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
+  <br />
+
+  <a href="https://atomgit.com/plait-board/drawnix" target="_blank"><img src="https://atomgit.com/plait-board/drawnix/star/new_badge.svg" alt="AtomGit G-Star" height="54" /></a>
 </div>
 
 [*中文*](https://github.com/plait-board/drawnix/blob/develop/README.md)


### PR DESCRIPTION
## Summary

- Add the official dynamic AtomGit G-Star badge to the Chinese and English READMEs.
- Link the badge to the Drawnix project hosted on AtomGit.
- Keep the two localized README variants consistent.

## Related Issue

N/A

## Validation

- [ ] Applicable checks pass: lint, format check, tests, and build
- [x] Relevant E2E and manual tests are complete or not applicable

Evidence, screenshots, or compatibility notes:

- `git diff --check origin/develop...HEAD` passes.
- The AtomGit project page and dynamic badge endpoint both return HTTP 200.
- `oxfmt` excludes the changed Markdown files. A repository-wide check reports 128 pre-existing formatting issues in files not touched by this PR.
- This is a documentation-only change; lint, tests, build, E2E, and `.drawnix` compatibility checks are not applicable.

## AI Assistance

Did you use AI tools to generate or substantially modify code, tests, or documentation in this pull request?

- [ ] No
- [x] Yes

If yes:

- **Tool/model:** Codex / GPT-5
- **AI-assisted work:** Verified the official AtomGit badge endpoint and updated `README.md` and `README_en.md` with the badge markup.
- **My review and validation:** I manually reviewed and previewed the rendered README change, confirmed the badge placement and destination, and understand and approve every submitted change.

- [x] I reviewed and understand the AI-assisted changes and can explain and maintain them

## Checklist

- [x] The title and description are in English, and the change is focused
- [x] I reviewed and understand every submitted change
- [x] Tests, documentation, and translations were updated when needed